### PR TITLE
Implement directional oxidation thickness controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,10 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Pointer interactions operate in micrometre space.  Use `canvasDistanceToWorld` when comparing hit-test radii so behaviour stays consistent after future zoom tweaks.
 - Mirror preview draws reflected copies instead of duplicating nodes.  Feed any new render passes the workspace `mirror` settings so reflected geometry stays in sync.
 - The pen tool only extends from contour endpoints and honours snaps to existing nodes; re-use `penDraft.activeEnd` when adding new gestural behaviours to avoid spawning duplicate vertices.
+
+## 2024-05-30 — Node editing affordances & measurement overhaul
+
+- Workspace state now tracks `nodeSelection`; canvas hit-tests update this so the Scene panel can expose node-level toggles.  When mutating geometry arrays call `pruneNodeSelection` (or mirror its behaviour) to keep the selection in sync and avoid dangling node ids.
+- `setNodeCurveMode` promotes/demotes a node’s adjacent segments between straight and Bézier defaults.  Reuse it from UI rather than crafting handles manually—this helper preserves mirror snapping and history bookkeeping.
+- The measurement store no longer keeps a history list.  Hovering the outer contour populates `hoverProbe`, dragging creates `dragProbe`, and the last action pins to `pinnedProbe`.  All renderers read these three fields; don’t reintroduce the old history array.
+- Directional oxidation weights auto-average diagonals (NE, SE, SW, NW) from their neighbouring cardinals.  UI inputs for diagonals are read-only, and non-zero headings must surface with accented labels so users can see which directions are active at a glance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,11 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Directional weights are edited through the on-canvas compass (`DirectionalCompass`).  Avoid reintroducing the old slider grid; keep this overlay responsive.
 - Scene management gained a local library persisted to `localStorage`.  Use the helpers in `workspaceStore` when adding export/import features so persistence stays consistent.
 - Default geometry comes from `createCircleNodes` (see `src/utils/presets.ts`).  Reuse that helper for any future circular presets to avoid duplicated constants.
+
+## 2024-05-28 — Oxidation synchronisation & contour hygiene
+
+- Oxidation defaults and the active selection stay in lock-step.  Use `updateSelectedOxidation` when adjusting per-path values so the geometry pipeline re-runs and history snapshots remain consistent.
+- Segment toggling (line ↔︎ Bézier) is handled in the store via `toggleSegmentCurve`.  Any future editing affordances should reuse that action to keep mirrored/closed path invariants intact.
+- Path endpoints auto-close when they approach within ~4 μm and mirror snapping pins points to the configured axes—avoid bypassing `mergeEndpointsIfClose` or `applyMirrorSnapping` when mutating node arrays.
+- Inner oxidation silhouettes are now cleaned with Clipper before resampling; if you extend the offset logic, feed new contours back through `cleanAndSimplifyPolygons` so ribbons never self-intersect.
+- UI and models now clamp oxide inputs to ≤ 10 μm.  Preserve `MAX_THICKNESS_UM` when introducing new entry points or validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,10 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Path endpoints auto-close when they approach within ~4 μm and mirror snapping pins points to the configured axes—avoid bypassing `mergeEndpointsIfClose` or `applyMirrorSnapping` when mutating node arrays.
 - Inner oxidation silhouettes are now cleaned with Clipper before resampling; if you extend the offset logic, feed new contours back through `cleanAndSimplifyPolygons` so ribbons never self-intersect.
 - UI and models now clamp oxide inputs to ≤ 10 μm.  Preserve `MAX_THICKNESS_UM` when introducing new entry points or validation.
+
+## 2024-05-29 — 50 μm viewport, mirrored previews & smarter pen
+
+- The canvas now renders a fixed 50 μm × 50 μm work area.  All canvas drawing helpers accept a `ViewTransform` and must convert world coordinates to screen space via `worldToCanvas`/`computeViewTransform`.
+- Pointer interactions operate in micrometre space.  Use `canvasDistanceToWorld` when comparing hit-test radii so behaviour stays consistent after future zoom tweaks.
+- Mirror preview draws reflected copies instead of duplicating nodes.  Feed any new render passes the workspace `mirror` settings so reflected geometry stays in sync.
+- The pen tool only extends from contour endpoints and honours snaps to existing nodes; re-use `penDraft.activeEnd` when adding new gestural behaviours to avoid spawning duplicate vertices.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# VISOXID Agent Handbook
+
+This project implements **Oxid Designer**, a Vite + React + TypeScript workbench for editing closed 2D contours, previewing directional oxidation offsets, and exporting results.  The application renders exclusively to an HTML `<canvas>` (no SVG) and uses Zustand for state.  Geometry helpers live under `src/geometry`, canvas drawing primitives under `src/canvas`, and UI panels/controls under `src/ui`.
+
+## Working Expectations
+
+- Keep the directional oxidation model intact.  Thickness is evaluated with a von Mises blend across the eight compass directions plus a uniform base term.  Geometry sampling, normals, smoothing, and offset visualisation flow through `workspaceStore.runGeometryPipeline()`.
+- Canvas interactions must respect the active tool in state (`select`, `pen`, `edit`, `measure`, etc.).  Selections, node manipulation, and measurement overlays are driven from `CanvasViewport` using store actions.
+- Units inside the UI are **micrometres (μm)**.  Never reintroduce raw pixel units in UI strings or overlays.
+- The oxide preview is drawn inside the canvas renderer.  Do not remove the gradient fill between the external contour and the oxidised inner contour unless a spec change requires it.
+
+## Documentation Discipline
+
+Whenever you make a material change (new feature, bug fix, behavioural tweak, schema change, etc.) you **must** update this handbook with:
+
+- A short description of the change and the rationale/bug it addresses.
+- Any new invariants or gotchas future agents need to respect.
+- Follow-up chores or tech debt created by the change.
+
+Think of this file as the living design history.  Out-of-date instructions cause regressions, so keep it synchronised with the codebase.
+
+## 2024-05-27 — Interactive editor & library overhaul
+
+- Canvas interactions now cover node dragging (select/edit), pen-based contour sketching, and measurement in μm.  Do not regress pointer-capture logic inside `CanvasViewport`—other tools depend on it.
+- Oxidation rendering draws a ribbon gradient between the base contour and the inner oxide preview.  Respect the `oxidationVisible` flag when adding new render passes.
+- Directional weights are edited through the on-canvas compass (`DirectionalCompass`).  Avoid reintroducing the old slider grid; keep this overlay responsive.
+- Scene management gained a local library persisted to `localStorage`.  Use the helpers in `workspaceStore` when adding export/import features so persistence stays consistent.
+- Default geometry comes from `createCircleNodes` (see `src/utils/presets.ts`).  Reuse that helper for any future circular presets to avoid duplicated constants.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ export const App = () => {
 
   useEffect(() => {
     if (!bootstrapped && pathCount === 0) {
-      addPath(createCircleNodes({ x: 360, y: 320 }, 180), {
+      addPath(createCircleNodes({ x: 25, y: 25 }, 18), {
         meta: {
           id: createId('path'),
           name: 'Reference circle',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { CanvasViewport } from './ui/CanvasViewport';
 import { ToolPanel } from './ui/ToolPanel';
+import { ScenePanel } from './ui/ScenePanel';
 import { OxidationPanel } from './ui/OxidationPanel';
 import { GridMirrorPanel } from './ui/GridMirrorPanel';
 import { MeasurementPanel } from './ui/MeasurementPanel';
@@ -9,52 +10,23 @@ import { ImportExportPanel } from './ui/ImportExportPanel';
 import { useKeyboardShortcuts } from './ui/useKeyboardShortcuts';
 import { useWorkspaceStore } from './state';
 import { createId } from './utils/ids';
-import type { PathNode } from './types';
-
-const createDemoNodes = (): PathNode[] => [
-  {
-    id: createId('node'),
-    point: { x: 180, y: 240 },
-    handleOut: { x: 260, y: 180 },
-  },
-  {
-    id: createId('node'),
-    point: { x: 360, y: 160 },
-    handleIn: { x: 300, y: 140 },
-    handleOut: { x: 420, y: 180 },
-  },
-  {
-    id: createId('node'),
-    point: { x: 480, y: 320 },
-    handleIn: { x: 460, y: 220 },
-    handleOut: { x: 520, y: 360 },
-  },
-  {
-    id: createId('node'),
-    point: { x: 340, y: 420 },
-    handleIn: { x: 420, y: 400 },
-    handleOut: { x: 260, y: 460 },
-  },
-  {
-    id: createId('node'),
-    point: { x: 200, y: 360 },
-    handleIn: { x: 240, y: 420 },
-  },
-];
+import { createCircleNodes } from './utils/presets';
 
 export const App = () => {
   useKeyboardShortcuts();
   const addPath = useWorkspaceStore((state) => state.addPath);
   const pushWarning = useWorkspaceStore((state) => state.pushWarning);
   const pathCount = useWorkspaceStore((state) => state.paths.length);
+  const bootstrapped = useWorkspaceStore((state) => state.bootstrapped);
+  const markBootstrapped = useWorkspaceStore((state) => state.markBootstrapped);
 
   useEffect(() => {
-    if (pathCount === 0) {
-      addPath(createDemoNodes(), {
+    if (!bootstrapped && pathCount === 0) {
+      addPath(createCircleNodes({ x: 360, y: 320 }, 180), {
         meta: {
           id: createId('path'),
-          name: 'Demo contour',
-          closed: false,
+          name: 'Reference circle',
+          closed: true,
           visible: true,
           locked: false,
           color: '#2563eb',
@@ -63,21 +35,23 @@ export const App = () => {
         },
       });
       pushWarning('Demo geometry loaded', 'info');
+      markBootstrapped();
     }
-  }, [addPath, pathCount, pushWarning]);
+  }, [addPath, bootstrapped, markBootstrapped, pathCount, pushWarning]);
 
   return (
-    <div className="min-h-screen bg-background px-6 py-8 text-text">
-      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+    <div className="min-h-screen bg-background px-4 py-6 text-text sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-screen-2xl flex-col gap-6">
         <header className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-semibold">VISOXID Workbench</h1>
             <p className="text-sm text-muted">Oxidation-aware contour planning with live measurement feedback.</p>
           </div>
         </header>
-        <main className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr_320px]">
+        <main className="grid grid-cols-1 gap-6 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
           <div className="flex flex-col gap-4">
             <ToolPanel />
+            <ScenePanel />
             <ImportExportPanel />
           </div>
           <CanvasViewport />

--- a/src/canvas/contours.ts
+++ b/src/canvas/contours.ts
@@ -5,11 +5,18 @@ const moveToPoint = (ctx: CanvasRenderingContext2D, x: number, y: number) => {
   ctx.moveTo(x, y);
 };
 
-const strokePolyline = (ctx: CanvasRenderingContext2D, points: Array<{ x: number; y: number }>) => {
+const strokePolyline = (
+  ctx: CanvasRenderingContext2D,
+  points: Array<{ x: number; y: number }>,
+  closed: boolean,
+) => {
   if (!points.length) return;
   moveToPoint(ctx, points[0].x, points[0].y);
   for (let i = 1; i < points.length; i += 1) {
     ctx.lineTo(points[i].x, points[i].y);
+  }
+  if (closed && points.length > 2) {
+    ctx.closePath();
   }
   ctx.stroke();
 };
@@ -18,6 +25,7 @@ export const drawContours = (
   ctx: CanvasRenderingContext2D,
   path: PathEntity,
   selected: boolean,
+  showOxide: boolean,
 ): void => {
   const samples =
     path.sampled?.samples ??
@@ -35,23 +43,44 @@ export const drawContours = (
   strokePolyline(
     ctx,
     samples.map((sample) => sample.position),
+    path.meta.closed,
   );
   ctx.restore();
-  if (!path.sampled) return;
-  // draw inner/outer contours using thickness information
-  const halfWidth = path.sampled.samples.map((sample) => sample.thickness / 2);
-  const outer = path.sampled.samples.map((sample, index) => ({
-    x: sample.position.x + sample.normal.x * halfWidth[index],
-    y: sample.position.y + sample.normal.y * halfWidth[index],
+  if (!showOxide || !path.sampled || path.sampled.samples.length < 2) return;
+  const inner = path.sampled.samples.map((sample) => ({
+    x: sample.position.x - sample.normal.x * sample.thickness,
+    y: sample.position.y - sample.normal.y * sample.thickness,
   }));
-  const inner = path.sampled.samples.map((sample, index) => ({
-    x: sample.position.x - sample.normal.x * halfWidth[index],
-    y: sample.position.y - sample.normal.y * halfWidth[index],
-  }));
+  const outer = path.sampled.samples.map((sample) => sample.position);
   ctx.save();
+  for (let i = 1; i < outer.length; i += 1) {
+    fillRibbon(ctx, outer[i - 1], outer[i], inner[i], inner[i - 1]);
+  }
+  if (path.meta.closed && outer.length > 2) {
+    fillRibbon(ctx, outer.at(-1)!, outer[0], inner[0], inner.at(-1)!);
+  }
   ctx.lineWidth = 1;
-  ctx.strokeStyle = 'rgba(37, 99, 235, 0.25)';
-  strokePolyline(ctx, outer);
-  strokePolyline(ctx, inner);
+  ctx.strokeStyle = 'rgba(37, 99, 235, 0.55)';
+  strokePolyline(ctx, inner, path.meta.closed);
   ctx.restore();
+};
+
+const fillRibbon = (
+  ctx: CanvasRenderingContext2D,
+  outerA: { x: number; y: number },
+  outerB: { x: number; y: number },
+  innerB: { x: number; y: number },
+  innerA: { x: number; y: number },
+) => {
+  const gradient = ctx.createLinearGradient(outerA.x, outerA.y, innerA.x, innerA.y);
+  gradient.addColorStop(0, 'rgba(37, 99, 235, 0.35)');
+  gradient.addColorStop(1, 'rgba(37, 99, 235, 0.05)');
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.moveTo(outerA.x, outerA.y);
+  ctx.lineTo(outerB.x, outerB.y);
+  ctx.lineTo(innerB.x, innerB.y);
+  ctx.lineTo(innerA.x, innerA.y);
+  ctx.closePath();
+  ctx.fill();
 };

--- a/src/canvas/contours.ts
+++ b/src/canvas/contours.ts
@@ -47,11 +47,13 @@ export const drawContours = (
   );
   ctx.restore();
   if (!showOxide || !path.sampled || path.sampled.samples.length < 2) return;
-  const inner = path.sampled.samples.map((sample) => ({
+  const outer = path.sampled.samples.map((sample) => sample.position);
+  const fallbackInner = path.sampled.samples.map((sample) => ({
     x: sample.position.x - sample.normal.x * sample.thickness,
     y: sample.position.y - sample.normal.y * sample.thickness,
   }));
-  const outer = path.sampled.samples.map((sample) => sample.position);
+  const innerSource = path.sampled.innerSamples ?? fallbackInner;
+  const inner = innerSource.length === outer.length ? innerSource : fallbackInner;
   ctx.save();
   for (let i = 1; i < outer.length; i += 1) {
     fillRibbon(ctx, outer[i - 1], outer[i], inner[i], inner[i - 1]);

--- a/src/canvas/contours.ts
+++ b/src/canvas/contours.ts
@@ -1,4 +1,5 @@
-import type { PathEntity } from '../types';
+import type { MirrorSettings, PathEntity, Vec2 } from '../types';
+import { worldToCanvas, type ViewTransform } from './viewTransform';
 
 const moveToPoint = (ctx: CanvasRenderingContext2D, x: number, y: number) => {
   ctx.beginPath();
@@ -26,6 +27,8 @@ export const drawContours = (
   path: PathEntity,
   selected: boolean,
   showOxide: boolean,
+  view: ViewTransform,
+  mirror?: MirrorSettings,
 ): void => {
   const samples =
     path.sampled?.samples ??
@@ -36,35 +39,57 @@ export const drawContours = (
     }));
   if (!samples.length) return;
   const strokeColor = selected ? '#2563eb' : path.meta.color;
-  ctx.save();
-  ctx.lineWidth = 1.8;
-  ctx.strokeStyle = strokeColor;
-  ctx.setLineDash(path.meta.closed ? [] : [6, 3]);
-  strokePolyline(
-    ctx,
-    samples.map((sample) => sample.position),
-    path.meta.closed,
-  );
-  ctx.restore();
-  if (!showOxide || !path.sampled || path.sampled.samples.length < 2) return;
-  const outer = path.sampled.samples.map((sample) => sample.position);
-  const fallbackInner = path.sampled.samples.map((sample) => ({
+  const outerWorld = path.sampled?.samples.map((sample) => sample.position) ?? [];
+  const fallbackInner = path.sampled?.samples.map((sample) => ({
     x: sample.position.x - sample.normal.x * sample.thickness,
     y: sample.position.y - sample.normal.y * sample.thickness,
   }));
-  const innerSource = path.sampled.innerSamples ?? fallbackInner;
-  const inner = innerSource.length === outer.length ? innerSource : fallbackInner;
-  ctx.save();
-  for (let i = 1; i < outer.length; i += 1) {
-    fillRibbon(ctx, outer[i - 1], outer[i], inner[i], inner[i - 1]);
+  const innerWorld =
+    path.sampled?.innerSamples && path.sampled.innerSamples.length === outerWorld.length
+      ? path.sampled.innerSamples
+      : fallbackInner ?? [];
+  const drawVariant = (outer: Vec2[], inner: Vec2[], emphasize: boolean) => {
+    const outerScreen = outer.map((pt) => worldToCanvas(pt, view));
+    const innerScreen = inner.map((pt) => worldToCanvas(pt, view));
+    ctx.save();
+    ctx.globalAlpha = emphasize ? 1 : 0.45;
+    ctx.lineWidth = 1.8;
+    ctx.strokeStyle = strokeColor;
+    ctx.setLineDash(path.meta.closed ? [] : [6, 3]);
+    strokePolyline(ctx, outerScreen, path.meta.closed);
+    if (showOxide && outerScreen.length > 1 && innerScreen.length === outerScreen.length) {
+      for (let i = 1; i < outerScreen.length; i += 1) {
+        fillRibbon(ctx, outerScreen[i - 1], outerScreen[i], innerScreen[i], innerScreen[i - 1]);
+      }
+      if (path.meta.closed && outerScreen.length > 2) {
+        fillRibbon(
+          ctx,
+          outerScreen.at(-1)!,
+          outerScreen[0],
+          innerScreen[0],
+          innerScreen.at(-1)!,
+        );
+      }
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = emphasize ? 'rgba(37, 99, 235, 0.7)' : 'rgba(37, 99, 235, 0.35)';
+      strokePolyline(ctx, innerScreen, path.meta.closed);
+    }
+    ctx.restore();
+  };
+
+  if (mirror?.enabled) {
+    const variants = createMirroredVariants(outerWorld, innerWorld, mirror);
+    variants.forEach(({ outer, inner }) => {
+      if (outer.length) {
+        drawVariant(outer, inner, false);
+      }
+    });
   }
-  if (path.meta.closed && outer.length > 2) {
-    fillRibbon(ctx, outer.at(-1)!, outer[0], inner[0], inner.at(-1)!);
-  }
-  ctx.lineWidth = 1;
-  ctx.strokeStyle = 'rgba(37, 99, 235, 0.55)';
-  strokePolyline(ctx, inner, path.meta.closed);
-  ctx.restore();
+  drawVariant(
+    outerWorld.length ? outerWorld : samples.map((sample) => sample.position),
+    innerWorld.length ? innerWorld : samples.map((sample) => sample.position),
+    true,
+  );
 };
 
 const fillRibbon = (
@@ -85,4 +110,43 @@ const fillRibbon = (
   ctx.lineTo(innerA.x, innerA.y);
   ctx.closePath();
   ctx.fill();
+};
+
+const createMirroredVariants = (
+  outer: Vec2[],
+  inner: Vec2[],
+  mirror: MirrorSettings,
+): Array<{ outer: Vec2[]; inner: Vec2[] }> => {
+  const variants: Array<{ outer: Vec2[]; inner: Vec2[] }> = [];
+  const mirrorX = mirror.axis === 'x' || mirror.axis === 'xy';
+  const mirrorY = mirror.axis === 'y' || mirror.axis === 'xy';
+  const mapPoints = (transform: (point: Vec2) => Vec2) => ({
+    outer: outer.map(transform),
+    inner: inner.map(transform),
+  });
+  if (mirrorY) {
+    variants.push(
+      mapPoints((pt) => ({
+        x: mirror.origin.x - (pt.x - mirror.origin.x),
+        y: pt.y,
+      })),
+    );
+  }
+  if (mirrorX) {
+    variants.push(
+      mapPoints((pt) => ({
+        x: pt.x,
+        y: mirror.origin.y - (pt.y - mirror.origin.y),
+      })),
+    );
+  }
+  if (mirror.axis === 'xy') {
+    variants.push(
+      mapPoints((pt) => ({
+        x: mirror.origin.x - (pt.x - mirror.origin.x),
+        y: mirror.origin.y - (pt.y - mirror.origin.y),
+      })),
+    );
+  }
+  return variants;
 };

--- a/src/canvas/grid.ts
+++ b/src/canvas/grid.ts
@@ -1,10 +1,10 @@
 import type { GridSettings } from '../types';
+import { VIEW_EXTENT_UM, worldToCanvas, type ViewTransform } from './viewTransform';
 
 export const drawGrid = (
   ctx: CanvasRenderingContext2D,
-  width: number,
-  height: number,
   settings: GridSettings,
+  view: ViewTransform,
 ): void => {
   if (!settings.visible) return;
   const spacing = Math.max(4, settings.spacing);
@@ -12,32 +12,39 @@ export const drawGrid = (
   ctx.save();
   ctx.lineWidth = 1;
   ctx.strokeStyle = 'rgba(148, 163, 184, 0.25)';
-  const originX = width / 2;
-  const originY = height / 2;
+  const extent = VIEW_EXTENT_UM;
   const subSpacing = spacing / subdivisions;
-  for (let x = originX % spacing; x <= width; x += spacing) {
+  for (let x = 0; x <= extent; x += spacing) {
+    const a = worldToCanvas({ x, y: 0 }, view);
+    const b = worldToCanvas({ x, y: extent }, view);
     ctx.beginPath();
-    ctx.moveTo(x, 0);
-    ctx.lineTo(x, height);
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
-  for (let y = originY % spacing; y <= height; y += spacing) {
+  for (let y = 0; y <= extent; y += spacing) {
+    const a = worldToCanvas({ x: 0, y }, view);
+    const b = worldToCanvas({ x: extent, y }, view);
     ctx.beginPath();
-    ctx.moveTo(0, y);
-    ctx.lineTo(width, y);
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
   ctx.strokeStyle = 'rgba(148, 163, 184, 0.15)';
-  for (let x = originX % subSpacing; x <= width; x += subSpacing) {
+  for (let x = 0; x <= extent; x += subSpacing) {
+    const a = worldToCanvas({ x, y: 0 }, view);
+    const b = worldToCanvas({ x, y: extent }, view);
     ctx.beginPath();
-    ctx.moveTo(x, 0);
-    ctx.lineTo(x, height);
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
-  for (let y = originY % subSpacing; y <= height; y += subSpacing) {
+  for (let y = 0; y <= extent; y += subSpacing) {
+    const a = worldToCanvas({ x: 0, y }, view);
+    const b = worldToCanvas({ x: extent, y }, view);
     ctx.beginPath();
-    ctx.moveTo(0, y);
-    ctx.lineTo(width, y);
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
   ctx.restore();

--- a/src/canvas/handles.ts
+++ b/src/canvas/handles.ts
@@ -1,9 +1,11 @@
 import type { PathEntity } from '../types';
+import { worldToCanvas, type ViewTransform } from './viewTransform';
 
 export const drawHandles = (
   ctx: CanvasRenderingContext2D,
   path: PathEntity,
   selected: boolean,
+  view: ViewTransform,
 ): void => {
   if (!selected) return;
   ctx.save();
@@ -12,21 +14,24 @@ export const drawHandles = (
   ctx.lineWidth = 1;
   path.nodes.forEach((node) => {
     const { point, handleIn, handleOut } = node;
+    const screenPoint = worldToCanvas(point, view);
     if (handleIn) {
+      const screenHandleIn = worldToCanvas(handleIn, view);
       ctx.beginPath();
-      ctx.moveTo(point.x, point.y);
-      ctx.lineTo(handleIn.x, handleIn.y);
+      ctx.moveTo(screenPoint.x, screenPoint.y);
+      ctx.lineTo(screenHandleIn.x, screenHandleIn.y);
       ctx.stroke();
-      drawHandlePoint(ctx, handleIn.x, handleIn.y, false);
+      drawHandlePoint(ctx, screenHandleIn.x, screenHandleIn.y, false);
     }
     if (handleOut) {
+      const screenHandleOut = worldToCanvas(handleOut, view);
       ctx.beginPath();
-      ctx.moveTo(point.x, point.y);
-      ctx.lineTo(handleOut.x, handleOut.y);
+      ctx.moveTo(screenPoint.x, screenPoint.y);
+      ctx.lineTo(screenHandleOut.x, screenHandleOut.y);
       ctx.stroke();
-      drawHandlePoint(ctx, handleOut.x, handleOut.y, false);
+      drawHandlePoint(ctx, screenHandleOut.x, screenHandleOut.y, false);
     }
-    drawHandlePoint(ctx, point.x, point.y, true);
+    drawHandlePoint(ctx, screenPoint.x, screenPoint.y, true);
   });
   ctx.restore();
 };

--- a/src/canvas/handles.ts
+++ b/src/canvas/handles.ts
@@ -1,4 +1,4 @@
-import type { PathEntity } from '../types';
+import type { NodeSelection, PathEntity } from '../types';
 import { worldToCanvas, type ViewTransform } from './viewTransform';
 
 export const drawHandles = (
@@ -6,12 +6,17 @@ export const drawHandles = (
   path: PathEntity,
   selected: boolean,
   view: ViewTransform,
+  nodeSelection: NodeSelection | null,
 ): void => {
   if (!selected) return;
   ctx.save();
   ctx.strokeStyle = 'rgba(37, 99, 235, 0.35)';
   ctx.fillStyle = '#2563eb';
   ctx.lineWidth = 1;
+  const selectedNodes =
+    nodeSelection && nodeSelection.pathId === path.meta.id
+      ? new Set(nodeSelection.nodeIds)
+      : null;
   path.nodes.forEach((node) => {
     const { point, handleIn, handleOut } = node;
     const screenPoint = worldToCanvas(point, view);
@@ -21,7 +26,7 @@ export const drawHandles = (
       ctx.moveTo(screenPoint.x, screenPoint.y);
       ctx.lineTo(screenHandleIn.x, screenHandleIn.y);
       ctx.stroke();
-      drawHandlePoint(ctx, screenHandleIn.x, screenHandleIn.y, false);
+      drawHandlePoint(ctx, screenHandleIn.x, screenHandleIn.y, false, false);
     }
     if (handleOut) {
       const screenHandleOut = worldToCanvas(handleOut, view);
@@ -29,9 +34,10 @@ export const drawHandles = (
       ctx.moveTo(screenPoint.x, screenPoint.y);
       ctx.lineTo(screenHandleOut.x, screenHandleOut.y);
       ctx.stroke();
-      drawHandlePoint(ctx, screenHandleOut.x, screenHandleOut.y, false);
+      drawHandlePoint(ctx, screenHandleOut.x, screenHandleOut.y, false, false);
     }
-    drawHandlePoint(ctx, screenPoint.x, screenPoint.y, true);
+    const isSelected = selectedNodes?.has(node.id) ?? false;
+    drawHandlePoint(ctx, screenPoint.x, screenPoint.y, true, isSelected);
   });
   ctx.restore();
 };
@@ -41,11 +47,16 @@ const drawHandlePoint = (
   x: number,
   y: number,
   anchor: boolean,
+  highlighted: boolean,
 ) => {
   ctx.beginPath();
   ctx.arc(x, y, anchor ? 5 : 4, 0, Math.PI * 2);
-  ctx.fillStyle = anchor ? '#2563eb' : '#94a3b8';
-  ctx.strokeStyle = '#ffffff';
+  if (anchor) {
+    ctx.fillStyle = highlighted ? '#1d4ed8' : '#2563eb';
+  } else {
+    ctx.fillStyle = '#94a3b8';
+  }
+  ctx.strokeStyle = highlighted ? '#1d4ed8' : '#ffffff';
   ctx.fill();
   ctx.stroke();
 };

--- a/src/canvas/heatmap.ts
+++ b/src/canvas/heatmap.ts
@@ -1,4 +1,5 @@
 import type { PathEntity } from '../types';
+import { worldToCanvas, type ViewTransform } from './viewTransform';
 
 const toHeatColor = (value: number, min: number, max: number): string => {
   const t = max === min ? 0 : (value - min) / (max - min);
@@ -9,6 +10,7 @@ const toHeatColor = (value: number, min: number, max: number): string => {
 export const drawHeatmap = (
   ctx: CanvasRenderingContext2D,
   path: PathEntity,
+  view: ViewTransform,
 ): void => {
   const samples = path.sampled?.samples;
   if (!samples?.length) return;
@@ -24,8 +26,10 @@ export const drawHeatmap = (
     const color = toHeatColor((prev.thickness + curr.thickness) / 2, min, max);
     ctx.strokeStyle = `${color}88`;
     ctx.beginPath();
-    ctx.moveTo(prev.position.x, prev.position.y);
-    ctx.lineTo(curr.position.x, curr.position.y);
+    const prevScreen = worldToCanvas(prev.position, view);
+    const currScreen = worldToCanvas(curr.position, view);
+    ctx.moveTo(prevScreen.x, prevScreen.y);
+    ctx.lineTo(currScreen.x, currScreen.y);
     ctx.stroke();
   }
   ctx.restore();

--- a/src/canvas/measurements.ts
+++ b/src/canvas/measurements.ts
@@ -1,4 +1,4 @@
-import type { MeasurementState } from '../types';
+import type { MeasurementProbe, MeasurementState } from '../types';
 import { toDegrees } from '../utils/math';
 import { worldToCanvas, type ViewTransform } from './viewTransform';
 
@@ -8,16 +8,28 @@ export const drawMeasurements = (
   view: ViewTransform,
 ): void => {
   ctx.save();
-  ctx.strokeStyle = '#2563eb';
-  ctx.fillStyle = '#2563eb';
-  ctx.lineWidth = 1.5;
-  const probes = measurements.activeProbe
-    ? [measurements.activeProbe, ...measurements.history]
-    : measurements.history;
-  probes.slice(0, 1).forEach((probe) => {
+  const entries: Array<{ probe: MeasurementProbe; tone: 'pinned' | 'drag' | 'hover' }> = [];
+  if (measurements.pinnedProbe) {
+    entries.push({ probe: measurements.pinnedProbe, tone: 'pinned' });
+  }
+  if (measurements.hoverProbe) {
+    entries.push({ probe: measurements.hoverProbe, tone: 'hover' });
+  }
+  if (measurements.dragProbe) {
+    entries.push({ probe: measurements.dragProbe, tone: 'drag' });
+  }
+  entries.forEach(({ probe, tone }) => {
     const aScreen = worldToCanvas(probe.a, view);
     const bScreen = worldToCanvas(probe.b, view);
     ctx.beginPath();
+    ctx.setLineDash([]);
+    ctx.lineWidth = tone === 'drag' ? 2 : 1.5;
+    if (tone === 'hover') {
+      ctx.strokeStyle = 'rgba(37, 99, 235, 0.45)';
+      ctx.setLineDash([6, 4]);
+    } else {
+      ctx.strokeStyle = '#2563eb';
+    }
     ctx.moveTo(aScreen.x, aScreen.y);
     ctx.lineTo(bScreen.x, bScreen.y);
     ctx.stroke();
@@ -25,26 +37,33 @@ export const drawMeasurements = (
     const midY = (aScreen.y + bScreen.y) / 2;
     const distanceLabel = `${probe.distance.toFixed(2)} μm`;
     const angleLabel = `${toDegrees(Math.atan2(probe.b.y - probe.a.y, probe.b.x - probe.a.x)).toFixed(1)}°`;
-    drawLabel(ctx, midX, midY, `${distanceLabel} • ${angleLabel}`);
+    const toneVariant = tone === 'hover' ? 'subtle' : 'strong';
+    drawLabel(ctx, midX, midY, `${distanceLabel} • ${angleLabel}`, toneVariant);
   });
   ctx.restore();
 };
 
-const drawLabel = (ctx: CanvasRenderingContext2D, x: number, y: number, text: string) => {
+const drawLabel = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  text: string,
+  tone: 'strong' | 'subtle',
+) => {
   ctx.save();
   ctx.font = '12px Inter, sans-serif';
   const padding = 6;
   const textMetrics = ctx.measureText(text);
   const width = textMetrics.width + padding * 2;
   const height = 20;
-  ctx.fillStyle = 'rgba(15, 23, 42, 0.85)';
-  ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
+  ctx.fillStyle = tone === 'strong' ? 'rgba(15, 23, 42, 0.85)' : 'rgba(148, 163, 184, 0.85)';
+  ctx.strokeStyle = tone === 'strong' ? 'rgba(255, 255, 255, 0.8)' : 'rgba(226, 232, 240, 0.9)';
   ctx.lineWidth = 1;
   ctx.beginPath();
   ctx.roundRect(x - width / 2, y - height / 2, width, height, 10);
   ctx.fill();
   ctx.stroke();
-  ctx.fillStyle = '#f8fafc';
+  ctx.fillStyle = tone === 'strong' ? '#f8fafc' : '#0f172a';
   ctx.fillText(text, x - textMetrics.width / 2, y + 4);
   ctx.restore();
 };

--- a/src/canvas/measurements.ts
+++ b/src/canvas/measurements.ts
@@ -1,9 +1,11 @@
 import type { MeasurementState } from '../types';
 import { toDegrees } from '../utils/math';
+import { worldToCanvas, type ViewTransform } from './viewTransform';
 
 export const drawMeasurements = (
   ctx: CanvasRenderingContext2D,
   measurements: MeasurementState,
+  view: ViewTransform,
 ): void => {
   ctx.save();
   ctx.strokeStyle = '#2563eb';
@@ -13,12 +15,14 @@ export const drawMeasurements = (
     ? [measurements.activeProbe, ...measurements.history]
     : measurements.history;
   probes.slice(0, 1).forEach((probe) => {
+    const aScreen = worldToCanvas(probe.a, view);
+    const bScreen = worldToCanvas(probe.b, view);
     ctx.beginPath();
-    ctx.moveTo(probe.a.x, probe.a.y);
-    ctx.lineTo(probe.b.x, probe.b.y);
+    ctx.moveTo(aScreen.x, aScreen.y);
+    ctx.lineTo(bScreen.x, bScreen.y);
     ctx.stroke();
-    const midX = (probe.a.x + probe.b.x) / 2;
-    const midY = (probe.a.y + probe.b.y) / 2;
+    const midX = (aScreen.x + bScreen.x) / 2;
+    const midY = (aScreen.y + bScreen.y) / 2;
     const distanceLabel = `${probe.distance.toFixed(2)} μm`;
     const angleLabel = `${toDegrees(Math.atan2(probe.b.y - probe.a.y, probe.b.x - probe.a.x)).toFixed(1)}°`;
     drawLabel(ctx, midX, midY, `${distanceLabel} • ${angleLabel}`);

--- a/src/canvas/measurements.ts
+++ b/src/canvas/measurements.ts
@@ -19,7 +19,7 @@ export const drawMeasurements = (
     ctx.stroke();
     const midX = (probe.a.x + probe.b.x) / 2;
     const midY = (probe.a.y + probe.b.y) / 2;
-    const distanceLabel = `${probe.distance.toFixed(2)} px`;
+    const distanceLabel = `${probe.distance.toFixed(2)} μm`;
     const angleLabel = `${toDegrees(Math.atan2(probe.b.y - probe.a.y, probe.b.x - probe.a.x)).toFixed(1)}°`;
     drawLabel(ctx, midX, midY, `${distanceLabel} • ${angleLabel}`);
   });

--- a/src/canvas/mirror.ts
+++ b/src/canvas/mirror.ts
@@ -1,10 +1,10 @@
 import type { MirrorSettings } from '../types';
+import { VIEW_EXTENT_UM, worldToCanvas, type ViewTransform } from './viewTransform';
 
 export const drawMirrorAxes = (
   ctx: CanvasRenderingContext2D,
-  width: number,
-  height: number,
   settings: MirrorSettings,
+  view: ViewTransform,
 ): void => {
   if (!settings.enabled) return;
   ctx.save();
@@ -12,15 +12,19 @@ export const drawMirrorAxes = (
   ctx.setLineDash([6, 6]);
   ctx.lineWidth = 1;
   if (settings.axis === 'x' || settings.axis === 'xy') {
+    const start = worldToCanvas({ x: 0, y: settings.origin.y }, view);
+    const end = worldToCanvas({ x: VIEW_EXTENT_UM, y: settings.origin.y }, view);
     ctx.beginPath();
-    ctx.moveTo(0, settings.origin.y);
-    ctx.lineTo(width, settings.origin.y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
   }
   if (settings.axis === 'y' || settings.axis === 'xy') {
+    const start = worldToCanvas({ x: settings.origin.x, y: 0 }, view);
+    const end = worldToCanvas({ x: settings.origin.x, y: VIEW_EXTENT_UM }, view);
     ctx.beginPath();
-    ctx.moveTo(settings.origin.x, 0);
-    ctx.lineTo(settings.origin.x, height);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
   }
   ctx.restore();

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -79,7 +79,7 @@ export class CanvasRenderer {
       if (showHeatmap) {
         drawHeatmap(this.ctx, path);
       }
-      drawContours(this.ctx, path, selected);
+      drawContours(this.ctx, path, selected, state.oxidationVisible);
       drawHandles(this.ctx, path, selected);
     });
     drawSnaps(this.ctx, state.paths, state.measurements);

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -82,7 +82,7 @@ export class CanvasRenderer {
         drawHeatmap(this.ctx, path, view);
       }
       drawContours(this.ctx, path, selected, state.oxidationVisible, view, state.mirror);
-      drawHandles(this.ctx, path, selected, view);
+      drawHandles(this.ctx, path, selected, view, state.nodeSelection);
     });
     drawSnaps(this.ctx, state.paths, state.measurements, view);
     drawMeasurements(this.ctx, state.measurements, view);

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -6,6 +6,7 @@ import { drawHeatmap } from './heatmap';
 import { drawSnaps } from './snaps';
 import { drawMeasurements } from './measurements';
 import { drawMirrorAxes } from './mirror';
+import { computeViewTransform } from './viewTransform';
 
 export type StateGetter = () => WorkspaceState;
 
@@ -71,19 +72,20 @@ export class CanvasRenderer {
     this.ctx.clearRect(0, 0, width, height);
     const logicalWidth = width / this.dpr;
     const logicalHeight = height / this.dpr;
-    drawGrid(this.ctx, logicalWidth, logicalHeight, state.grid);
-    drawMirrorAxes(this.ctx, logicalWidth, logicalHeight, state.mirror);
+    const view = computeViewTransform(logicalWidth, logicalHeight);
+    drawGrid(this.ctx, state.grid, view);
+    drawMirrorAxes(this.ctx, state.mirror, view);
     const showHeatmap = state.measurements.showHeatmap;
     state.paths.forEach((path) => {
       const selected = state.selectedPathIds.includes(path.meta.id);
       if (showHeatmap) {
-        drawHeatmap(this.ctx, path);
+        drawHeatmap(this.ctx, path, view);
       }
-      drawContours(this.ctx, path, selected, state.oxidationVisible);
-      drawHandles(this.ctx, path, selected);
+      drawContours(this.ctx, path, selected, state.oxidationVisible, view, state.mirror);
+      drawHandles(this.ctx, path, selected, view);
     });
-    drawSnaps(this.ctx, state.paths, state.measurements);
-    drawMeasurements(this.ctx, state.measurements);
+    drawSnaps(this.ctx, state.paths, state.measurements, view);
+    drawMeasurements(this.ctx, state.measurements, view);
     this.ctx.restore();
   }
 }

--- a/src/canvas/snaps.ts
+++ b/src/canvas/snaps.ts
@@ -1,9 +1,11 @@
 import type { MeasurementState, PathEntity } from '../types';
+import { worldToCanvas, type ViewTransform } from './viewTransform';
 
 export const drawSnaps = (
   ctx: CanvasRenderingContext2D,
   paths: PathEntity[],
   measurements: MeasurementState,
+  view: ViewTransform,
 ): void => {
   if (!measurements.snapping) return;
   ctx.save();
@@ -15,14 +17,17 @@ export const drawSnaps = (
       if (snapPoints.has(key)) return;
       snapPoints.add(key);
       ctx.beginPath();
-      ctx.arc(node.point.x, node.point.y, 3, 0, Math.PI * 2);
+      const screen = worldToCanvas(node.point, view);
+      ctx.arc(screen.x, screen.y, 3, 0, Math.PI * 2);
       ctx.fill();
     });
   });
   if (measurements.activeProbe) {
     const { a, b } = measurements.activeProbe;
-    drawSnap(ctx, a.x, a.y, true);
-    drawSnap(ctx, b.x, b.y, true);
+    const aScreen = worldToCanvas(a, view);
+    const bScreen = worldToCanvas(b, view);
+    drawSnap(ctx, aScreen.x, aScreen.y, true);
+    drawSnap(ctx, bScreen.x, bScreen.y, true);
   }
   ctx.restore();
 };

--- a/src/canvas/snaps.ts
+++ b/src/canvas/snaps.ts
@@ -1,4 +1,4 @@
-import type { MeasurementState, PathEntity } from '../types';
+import type { MeasurementProbe, MeasurementState, PathEntity } from '../types';
 import { worldToCanvas, type ViewTransform } from './viewTransform';
 
 export const drawSnaps = (
@@ -22,13 +22,15 @@ export const drawSnaps = (
       ctx.fill();
     });
   });
-  if (measurements.activeProbe) {
-    const { a, b } = measurements.activeProbe;
-    const aScreen = worldToCanvas(a, view);
-    const bScreen = worldToCanvas(b, view);
+  const probeCandidates = [measurements.pinnedProbe, measurements.dragProbe].filter(
+    (probe): probe is MeasurementProbe => Boolean(probe),
+  );
+  probeCandidates.forEach((probe) => {
+    const aScreen = worldToCanvas(probe.a, view);
+    const bScreen = worldToCanvas(probe.b, view);
     drawSnap(ctx, aScreen.x, aScreen.y, true);
     drawSnap(ctx, bScreen.x, bScreen.y, true);
-  }
+  });
   ctx.restore();
 };
 

--- a/src/canvas/viewTransform.ts
+++ b/src/canvas/viewTransform.ts
@@ -1,0 +1,35 @@
+import type { Vec2 } from '../types';
+
+export interface ViewTransform {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  extent: number;
+}
+
+export const VIEW_EXTENT_UM = 50;
+
+export const computeViewTransform = (width: number, height: number): ViewTransform => {
+  const extent = VIEW_EXTENT_UM;
+  const span = Math.max(Math.min(width, height), 1);
+  const scale = span / extent || 1;
+  const offsetX = (width - extent * scale) / 2;
+  const offsetY = (height - extent * scale) / 2;
+  return { scale: scale || 1, offsetX, offsetY, extent };
+};
+
+export const worldToCanvas = (point: Vec2, view: ViewTransform): Vec2 => ({
+  x: view.offsetX + point.x * view.scale,
+  y: view.offsetY + point.y * view.scale,
+});
+
+export const canvasToWorld = (point: Vec2, view: ViewTransform): Vec2 => ({
+  x: (point.x - view.offsetX) / view.scale,
+  y: (point.y - view.offsetY) / view.scale,
+});
+
+export const worldDistanceToCanvas = (distance: number, view: ViewTransform): number =>
+  distance * view.scale;
+
+export const canvasDistanceToWorld = (distance: number, view: ViewTransform): number =>
+  distance / view.scale;

--- a/src/geometry/offset.ts
+++ b/src/geometry/offset.ts
@@ -2,6 +2,7 @@
 // @ts-ignore - clipper-lib lacks ESM typings
 import ClipperLib from 'clipper-lib';
 import type { Vec2 } from '../types';
+import { distance, lerp } from '../utils/math';
 
 const SCALE = 10_000;
 
@@ -18,9 +19,21 @@ type IntPoint = { X: number; Y: number };
 type ClipperModule = {
   JoinType: { jtMiter: number; jtRound: number; jtSquare: number };
   EndType: { etClosedPolygon: number };
+  PolyFillType: {
+    pftEvenOdd: number;
+    pftNonZero: number;
+    pftPositive: number;
+    pftNegative: number;
+  };
   ClipperOffset: new (miterLimit?: number, arcTolerance?: number) => {
     AddPath(path: IntPoint[], joinType: number, endType: number): void;
     Execute(delta: number): IntPoint[][];
+  };
+  Clipper: {
+    CleanPolygon(path: IntPoint[], distance: number): IntPoint[];
+    CleanPolygons(polys: IntPoint[][], distance: number): IntPoint[][];
+    SimplifyPolygon(path: IntPoint[], fillType: number): IntPoint[][];
+    SimplifyPolygons(polys: IntPoint[][], fillType: number): IntPoint[][];
   };
 };
 
@@ -40,4 +53,74 @@ export const computeOffset = (path: Vec2[], options: OffsetOptions): Vec2[][] =>
   offset.AddPath(integerPath, joinMap[joinStyle], clipper.EndType.etClosedPolygon);
   const solution = offset.Execute(delta * SCALE);
   return solution.map((poly) => poly.map((pt) => ({ x: pt.X / SCALE, y: pt.Y / SCALE })));
+};
+
+const toIntPoint = (point: Vec2): IntPoint => ({
+  X: Math.round(point.x * SCALE),
+  Y: Math.round(point.y * SCALE),
+});
+
+const fromIntPoint = (point: IntPoint): Vec2 => ({ x: point.X / SCALE, y: point.Y / SCALE });
+
+const toIntPath = (path: Vec2[]): IntPoint[] => path.map(toIntPoint);
+
+const fromIntPath = (path: IntPoint[]): Vec2[] => path.map(fromIntPoint);
+
+export const cleanAndSimplifyPolygons = (path: Vec2[], tolerance = 0.25): Vec2[][] => {
+  if (path.length < 3) return [];
+  const intPath = toIntPath(path);
+  const cleaned = clipper.Clipper.CleanPolygon(intPath, Math.max(1, Math.round(tolerance * SCALE)));
+  if (cleaned.length < 3) {
+    return [];
+  }
+  const simplified = clipper.Clipper.SimplifyPolygon(cleaned, clipper.PolyFillType.pftNonZero);
+  if (!simplified.length) {
+    return [fromIntPath(cleaned)];
+  }
+  return simplified.map(fromIntPath);
+};
+
+export const polygonArea = (polygon: Vec2[]): number => {
+  if (polygon.length < 3) return 0;
+  let area = 0;
+  for (let i = 0; i < polygon.length; i += 1) {
+    const current = polygon[i];
+    const next = polygon[(i + 1) % polygon.length];
+    area += current.x * next.y - next.x * current.y;
+  }
+  return area / 2;
+};
+
+export const resampleClosedPolygon = (polygon: Vec2[], count: number): Vec2[] => {
+  if (!polygon.length || count <= 0) return [];
+  const segments: number[] = [];
+  let totalLength = 0;
+  for (let i = 0; i < polygon.length; i += 1) {
+    const current = polygon[i];
+    const next = polygon[(i + 1) % polygon.length];
+    const len = distance(current, next);
+    segments.push(len);
+    totalLength += len;
+  }
+  if (totalLength === 0) {
+    return Array.from({ length: count }, () => ({ ...polygon[0] }));
+  }
+  const samples: Vec2[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const target = (i / count) * totalLength;
+    let accumulated = 0;
+    for (let seg = 0; seg < polygon.length; seg += 1) {
+      const segLength = segments[seg];
+      const nextAccum = accumulated + segLength;
+      if (target <= nextAccum || seg === polygon.length - 1) {
+        const t = segLength === 0 ? 0 : (target - accumulated) / segLength;
+        const start = polygon[seg];
+        const end = polygon[(seg + 1) % polygon.length];
+        samples.push(lerp(start, end, Math.min(Math.max(t, 0), 1)));
+        break;
+      }
+      accumulated = nextAccum;
+    }
+  }
+  return samples;
 };

--- a/src/geometry/thickness.ts
+++ b/src/geometry/thickness.ts
@@ -1,41 +1,99 @@
-import type { SamplePoint } from '../types';
-import { gaussianKernel, vonMisesKernel, angleBetween, distance } from '../utils/math';
+import type { DirectionWeight, DirKey, SamplePoint } from '../types';
 
 export interface ThicknessOptions {
-  kernelWidth: number;
-  baseThickness: number;
-  targetThickness: number;
-  vonMisesKappa: number;
+  uniformThickness: number;
+  weights: DirectionWeight[];
+  kappa: number;
   mirrorSymmetry?: boolean;
 }
+
+const DIR_SEQUENCE: DirKey[] = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+
+const DIR_ANGLES: Record<DirKey, number> = {
+  E: 0,
+  NE: Math.PI / 4,
+  N: Math.PI / 2,
+  NW: (3 * Math.PI) / 4,
+  W: Math.PI,
+  SW: (-3 * Math.PI) / 4,
+  S: -Math.PI / 2,
+  SE: -Math.PI / 4,
+};
+
+const MIRROR_PAIRS: [DirKey, DirKey][] = [
+  ['E', 'W'],
+  ['NE', 'NW'],
+  ['SE', 'SW'],
+];
+
+const normalizeWeights = (
+  weights: DirectionWeight[],
+  mirrorSymmetry?: boolean,
+): Record<DirKey, number> => {
+  const lookup: Record<DirKey, number> = {
+    N: 0,
+    NE: 0,
+    E: 0,
+    SE: 0,
+    S: 0,
+    SW: 0,
+    W: 0,
+    NW: 0,
+  };
+  for (const weight of weights) {
+    lookup[weight.dir] = weight.valueUm;
+  }
+  if (mirrorSymmetry) {
+    for (const [a, b] of MIRROR_PAIRS) {
+      const average = (lookup[a] + lookup[b]) / 2;
+      lookup[a] = average;
+      lookup[b] = average;
+    }
+  }
+  return lookup;
+};
 
 export const evalThickness = (
   samples: SamplePoint[],
   options: ThicknessOptions,
 ): SamplePoint[] => {
-  const { kernelWidth, baseThickness, targetThickness, vonMisesKappa, mirrorSymmetry } = options;
-  const updated = samples.map((sample) => ({ ...sample }));
-  const maxDistance = kernelWidth * 3;
-  for (let i = 0; i < samples.length; i += 1) {
-    let weightSum = 0;
-    let accum = 0;
-    const pivot = samples[i];
-    for (let j = 0; j < samples.length; j += 1) {
-      const neighbor = samples[j];
-      const dist = distance(pivot.position, neighbor.position);
-      if (dist > maxDistance) continue;
-      const angular = Math.abs(angleBetween(pivot.normal, neighbor.normal));
-      const gaussian = gaussianKernel(dist, kernelWidth);
-      const vm = vonMisesKernel(angular, vonMisesKappa);
-      const weight = gaussian * vm;
-      weightSum += weight;
-      const neighborThickness = neighbor.thickness || baseThickness;
-      accum += neighborThickness * weight;
+  const { uniformThickness, weights, kappa, mirrorSymmetry } = options;
+  const lookup = normalizeWeights(weights, mirrorSymmetry);
+  const safeKappa = Math.max(0, Number.isFinite(kappa) ? kappa : 0);
+
+  return samples.map((sample) => {
+    const theta = Math.atan2(sample.normal.y, sample.normal.x);
+    let numerator = 0;
+    let denominator = 0;
+    for (const dir of DIR_SEQUENCE) {
+      const phi = DIR_ANGLES[dir];
+      const kernel = Math.exp(safeKappa * Math.cos(theta - phi));
+      denominator += kernel;
+      numerator += lookup[dir] * kernel;
     }
-    const base = weightSum > 0 ? accum / weightSum : baseThickness;
-    const lerpFactor = Math.min(1, weightSum * 0.75);
-    const blended = base * (1 - lerpFactor) + targetThickness * lerpFactor;
-    updated[i].thickness = mirrorSymmetry ? (blended + baseThickness) / 2 : blended;
+    const directional = denominator > 0 ? numerator / denominator : 0;
+    return {
+      ...sample,
+      thickness: uniformThickness + directional,
+    };
+  });
+};
+
+export const evalThicknessForAngle = (
+  thetaRad: number,
+  options: ThicknessOptions,
+): number => {
+  const { uniformThickness, weights, kappa, mirrorSymmetry } = options;
+  const lookup = normalizeWeights(weights, mirrorSymmetry);
+  const safeKappa = Math.max(0, Number.isFinite(kappa) ? kappa : 0);
+  let numerator = 0;
+  let denominator = 0;
+  for (const dir of DIR_SEQUENCE) {
+    const phi = DIR_ANGLES[dir];
+    const kernel = Math.exp(safeKappa * Math.cos(thetaRad - phi));
+    denominator += kernel;
+    numerator += lookup[dir] * kernel;
   }
-  return updated;
+  const directional = denominator > 0 ? numerator / denominator : 0;
+  return uniformThickness + directional;
 };

--- a/src/geometry/thickness.ts
+++ b/src/geometry/thickness.ts
@@ -11,13 +11,13 @@ const DIR_SEQUENCE: DirKey[] = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
 
 const DIR_ANGLES: Record<DirKey, number> = {
   E: 0,
-  NE: Math.PI / 4,
-  N: Math.PI / 2,
-  NW: (3 * Math.PI) / 4,
+  NE: -Math.PI / 4,
+  N: -Math.PI / 2,
+  NW: (-3 * Math.PI) / 4,
   W: Math.PI,
-  SW: (-3 * Math.PI) / 4,
-  S: -Math.PI / 2,
-  SE: -Math.PI / 4,
+  SW: (3 * Math.PI) / 4,
+  S: Math.PI / 2,
+  SE: Math.PI / 4,
 };
 
 const MIRROR_PAIRS: [DirKey, DirKey][] = [
@@ -43,6 +43,10 @@ const normalizeWeights = (
   for (const weight of weights) {
     lookup[weight.dir] = weight.valueUm;
   }
+  lookup.NE = (lookup.N + lookup.E) / 2;
+  lookup.SE = (lookup.S + lookup.E) / 2;
+  lookup.SW = (lookup.S + lookup.W) / 2;
+  lookup.NW = (lookup.N + lookup.W) / 2;
   if (mirrorSymmetry) {
     for (const [a, b] of MIRROR_PAIRS) {
       const average = (lookup[a] + lookup[b]) / 2;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,18 @@ export interface PathNode {
   timestamp?: number;
 }
 
+export type DirKey = 'N' | 'NE' | 'E' | 'SE' | 'S' | 'SW' | 'W' | 'NW';
+
+export interface DirectionWeight {
+  dir: DirKey;
+  valueUm: number;
+}
+
+export interface WeightsByDirection {
+  items: DirectionWeight[];
+  kappa: number;
+}
+
 export interface PathMeta {
   id: string;
   name: string;
@@ -48,13 +60,11 @@ export interface SampledPath {
 }
 
 export interface OxidationSettings {
-  kernelWidth: number;
-  targetThickness: number;
-  baseThickness: number;
+  thicknessUniformUm: number;
+  thicknessByDirection: WeightsByDirection;
   smoothingIterations: number;
   smoothingStrength: number;
   evaluationSpacing: number;
-  vonMisesKappa: number;
   mirrorSymmetry: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export interface SampledPath {
   id: string;
   samples: SamplePoint[];
   length: number;
+  innerSamples?: Vec2[];
+  innerPolygons?: Vec2[][];
 }
 
 export interface OxidationSettings {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,15 @@ export interface OxidationPreset {
   settings: OxidationSettings;
 }
 
+export interface StoredShape {
+  id: string;
+  name: string;
+  nodes: PathNode[];
+  oxidation: OxidationSettings;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface GridSettings {
   visible: boolean;
   snapToGrid: boolean;
@@ -138,6 +147,9 @@ export interface WorkspaceState {
   history: WorkspaceSnapshot[];
   future: WorkspaceSnapshot[];
   dirty: boolean;
+  oxidationVisible: boolean;
+  bootstrapped: boolean;
+  library: StoredShape[];
 }
 
 export interface ExportedProject {

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,10 +110,16 @@ export interface MeasurementProbe {
 }
 
 export interface MeasurementState {
-  activeProbe: MeasurementProbe | null;
-  history: MeasurementProbe[];
+  hoverProbe: MeasurementProbe | null;
+  pinnedProbe: MeasurementProbe | null;
+  dragProbe: MeasurementProbe | null;
   snapping: boolean;
   showHeatmap: boolean;
+}
+
+export interface NodeSelection {
+  pathId: string;
+  nodeIds: string[];
 }
 
 export interface PathEntity {
@@ -135,11 +141,13 @@ export interface WorkspaceSnapshot {
   paths: PathEntity[];
   selectedPathIds: string[];
   activeTool: ToolId;
+  nodeSelection: NodeSelection | null;
 }
 
 export interface WorkspaceState {
   paths: PathEntity[];
   selectedPathIds: string[];
+  nodeSelection: NodeSelection | null;
   activeTool: ToolId;
   grid: GridSettings;
   mirror: MirrorSettings;

--- a/src/ui/CanvasViewport.tsx
+++ b/src/ui/CanvasViewport.tsx
@@ -1,9 +1,34 @@
-import { useEffect, useRef, type PointerEvent } from 'react';
+import { useEffect, useRef, useState, type PointerEvent } from 'react';
 import { createRenderer } from '../canvas/renderer';
 import { useWorkspaceStore } from '../state';
 import { createId } from '../utils/ids';
 import { distance, toDegrees } from '../utils/math';
-import type { Vec2 } from '../types';
+import type { PathEntity, Vec2 } from '../types';
+import { DirectionalCompass } from './DirectionalCompass';
+
+type DragTarget =
+  | { kind: 'anchor'; pathId: string; nodeId: string }
+  | { kind: 'handleIn' | 'handleOut'; pathId: string; nodeId: string };
+
+const nodeHitThreshold = 12;
+const pathHitThreshold = 10;
+
+const pointSegmentDistance = (p: Vec2, a: Vec2, b: Vec2): number => {
+  const ab = { x: b.x - a.x, y: b.y - a.y };
+  const ap = { x: p.x - a.x, y: p.y - a.y };
+  const abLenSq = ab.x * ab.x + ab.y * ab.y;
+  const t = abLenSq === 0 ? 0 : Math.max(0, Math.min(1, (ap.x * ab.x + ap.y * ab.y) / abLenSq));
+  const closest = { x: a.x + ab.x * t, y: a.y + ab.y * t };
+  return distance(p, closest);
+};
+
+const orderPathsBySelection = (paths: PathEntity[], selectedIds: string[]): PathEntity[] => {
+  const selectedSet = new Set(selectedIds);
+  return [
+    ...paths.filter((path) => selectedSet.has(path.meta.id)),
+    ...paths.filter((path) => !selectedSet.has(path.meta.id)),
+  ];
+};
 
 export const CanvasViewport = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -11,7 +36,14 @@ export const CanvasViewport = () => {
   const setProbe = useWorkspaceStore((state) => state.setProbe);
   const addProbe = useWorkspaceStore((state) => state.addProbe);
   const measurements = useWorkspaceStore((state) => state.measurements);
+  const setSelected = useWorkspaceStore((state) => state.setSelected);
+  const updatePath = useWorkspaceStore((state) => state.updatePath);
+  const addPath = useWorkspaceStore((state) => state.addPath);
+  const setPathMeta = useWorkspaceStore((state) => state.setPathMeta);
   const measureStart = useRef<Vec2 | null>(null);
+  const dragTarget = useRef<DragTarget | null>(null);
+  const penDraft = useRef<{ pathId: string } | null>(null);
+  const [cursorHint, setCursorHint] = useState<string | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -29,41 +61,196 @@ export const CanvasViewport = () => {
     };
   };
 
+  const hitTestNodes = (position: Vec2): DragTarget | null => {
+    const state = useWorkspaceStore.getState();
+    const ordered = orderPathsBySelection(state.paths, state.selectedPathIds);
+    for (const path of ordered) {
+      for (const node of path.nodes) {
+        if (distance(position, node.point) <= nodeHitThreshold) {
+          return { kind: 'anchor', pathId: path.meta.id, nodeId: node.id };
+        }
+        if (node.handleIn && distance(position, node.handleIn) <= nodeHitThreshold) {
+          return { kind: 'handleIn', pathId: path.meta.id, nodeId: node.id };
+        }
+        if (node.handleOut && distance(position, node.handleOut) <= nodeHitThreshold) {
+          return { kind: 'handleOut', pathId: path.meta.id, nodeId: node.id };
+        }
+      }
+    }
+    return null;
+  };
+
+  const hitTestPath = (position: Vec2): string | null => {
+    const state = useWorkspaceStore.getState();
+    for (const path of state.paths) {
+      const samples = path.sampled?.samples ?? [];
+      if (samples.length) {
+        for (let i = 1; i < samples.length; i += 1) {
+          if (pointSegmentDistance(position, samples[i - 1].position, samples[i].position) <= pathHitThreshold) {
+            return path.meta.id;
+          }
+        }
+      } else if (path.nodes.length > 1) {
+        for (let i = 1; i < path.nodes.length; i += 1) {
+          if (pointSegmentDistance(position, path.nodes[i - 1].point, path.nodes[i].point) <= pathHitThreshold) {
+            return path.meta.id;
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  const updateGeometryForDrag = (target: DragTarget, position: Vec2) => {
+    updatePath(target.pathId, (nodes) =>
+      nodes.map((node) => {
+        if (node.id !== target.nodeId) return node;
+        if (target.kind === 'anchor') {
+          return { ...node, point: position };
+        }
+        if (target.kind === 'handleIn') {
+          return { ...node, handleIn: position };
+        }
+        return { ...node, handleOut: position };
+      }),
+    );
+  };
+
+  const handlePenInput = (position: Vec2, clicks: number) => {
+    const state = useWorkspaceStore.getState();
+    if (!penDraft.current) {
+      const pathId = addPath(
+        [
+          {
+            id: createId('node'),
+            point: position,
+            handleIn: null,
+            handleOut: null,
+          },
+        ],
+        {
+          meta: {
+            id: createId('path'),
+            name: 'Sketch',
+            closed: false,
+            visible: true,
+            locked: false,
+            color: '#2563eb',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        },
+      );
+      penDraft.current = { pathId };
+      setSelected([pathId]);
+      setCursorHint('Click to add points, double-click first point to close');
+      return;
+    }
+    const path = state.paths.find((entry) => entry.meta.id === penDraft.current?.pathId);
+    if (!path) {
+      penDraft.current = null;
+      setCursorHint(null);
+      return;
+    }
+    const firstNode = path.nodes[0];
+    if (path.nodes.length >= 3 && distance(position, firstNode.point) < nodeHitThreshold + 4) {
+      setPathMeta(path.meta.id, { closed: true });
+      penDraft.current = null;
+      setCursorHint(null);
+      return;
+    }
+    if (clicks >= 2 && path.nodes.length >= 2) {
+      setPathMeta(path.meta.id, { closed: true });
+      penDraft.current = null;
+      setCursorHint(null);
+      return;
+    }
+    updatePath(path.meta.id, (nodes) => [
+      ...nodes,
+      {
+        id: createId('node'),
+        point: position,
+        handleIn: null,
+        handleOut: null,
+      },
+    ]);
+  };
+
   const handlePointerDown = (event: PointerEvent<HTMLCanvasElement>) => {
-    if (activeTool !== 'measure') return;
     const position = getPointerPos(event);
-    const probe = {
-      id: createId('probe'),
-      a: position,
-      b: position,
-      distance: 0,
-      angleDeg: 0,
-    };
-    measureStart.current = position;
-    setProbe(probe);
+    if (activeTool === 'measure') {
+      const probe = {
+        id: createId('probe'),
+        a: position,
+        b: position,
+        distance: 0,
+        angleDeg: 0,
+      };
+      measureStart.current = position;
+      setProbe(probe);
+      canvasRef.current?.setPointerCapture(event.pointerId);
+      return;
+    }
+    if (activeTool === 'pen') {
+      handlePenInput(position, event.detail);
+      canvasRef.current?.setPointerCapture(event.pointerId);
+      return;
+    }
+    if (activeTool === 'select' || activeTool === 'edit') {
+      const target = hitTestNodes(position);
+      if (target) {
+        dragTarget.current = target;
+        setSelected([target.pathId]);
+        updateGeometryForDrag(target, position);
+        canvasRef.current?.setPointerCapture(event.pointerId);
+        return;
+      }
+      const pathId = hitTestPath(position);
+      if (pathId) {
+        setSelected([pathId]);
+      } else if (!event.shiftKey) {
+        setSelected([]);
+      }
+      return;
+    }
   };
 
   const handlePointerMove = (event: PointerEvent<HTMLCanvasElement>) => {
-    if (activeTool !== 'measure' || !measureStart.current || !measurements.activeProbe) return;
-    const pos = getPointerPos(event);
-    const dist = distance(measureStart.current, pos);
-    const angle = toDegrees(Math.atan2(pos.y - measureStart.current.y, pos.x - measureStart.current.x));
-    setProbe({
-      ...measurements.activeProbe,
-      b: pos,
-      distance: dist,
-      angleDeg: angle,
-    });
+    const position = getPointerPos(event);
+    if (activeTool === 'measure' && measureStart.current && measurements.activeProbe) {
+      const dist = distance(measureStart.current, position);
+      const angle = toDegrees(Math.atan2(position.y - measureStart.current.y, position.x - measureStart.current.x));
+      setProbe({
+        ...measurements.activeProbe,
+        b: position,
+        distance: dist,
+        angleDeg: angle,
+      });
+      return;
+    }
+    if ((activeTool === 'select' || activeTool === 'edit') && dragTarget.current) {
+      updateGeometryForDrag(dragTarget.current, position);
+    }
   };
 
-  const handlePointerUp = () => {
-    if (activeTool !== 'measure' || !measurements.activeProbe) return;
-    addProbe(measurements.activeProbe);
-    measureStart.current = null;
+  const handlePointerUp = (event: PointerEvent<HTMLCanvasElement>) => {
+    if (activeTool === 'measure' && measurements.activeProbe) {
+      addProbe(measurements.activeProbe);
+      measureStart.current = null;
+    }
+    dragTarget.current = null;
+    canvasRef.current?.releasePointerCapture(event.pointerId);
   };
+
+  useEffect(() => {
+    if (activeTool !== 'pen') {
+      penDraft.current = null;
+      setCursorHint(null);
+    }
+  }, [activeTool]);
 
   return (
-    <div className="relative h-full w-full overflow-hidden rounded-3xl border border-border bg-surface shadow-panel">
+    <div className="relative h-full min-h-[420px] w-full overflow-hidden rounded-3xl border border-border bg-surface shadow-panel">
       <canvas
         ref={canvasRef}
         className="h-full w-full touch-none"
@@ -72,8 +259,11 @@ export const CanvasViewport = () => {
         onPointerUp={handlePointerUp}
         onPointerLeave={handlePointerUp}
       />
-      {activeTool === 'measure' && (
-        <div className="pointer-events-none absolute left-4 top-4 rounded-xl bg-white/90 px-3 py-2 text-xs font-medium text-muted shadow">Click & drag to measure</div>
+      <DirectionalCompass />
+      {(activeTool === 'measure' || cursorHint) && (
+        <div className="pointer-events-none absolute left-4 top-4 rounded-xl bg-white/90 px-3 py-2 text-xs font-medium text-muted shadow">
+          {activeTool === 'measure' ? 'Click & drag to measure (μm)' : cursorHint}
+        </div>
       )}
     </div>
   );

--- a/src/ui/DirectionalCompass.tsx
+++ b/src/ui/DirectionalCompass.tsx
@@ -81,6 +81,12 @@ export const DirectionalCompass = () => {
           const radians = (entry.angle * Math.PI) / 180;
           const offsetX = Math.cos(radians) * radius;
           const offsetY = Math.sin(radians) * radius;
+          const value = valueLookup[entry.dir];
+          const isDiagonal = entry.dir.length > 1;
+          const active = Math.abs(value) > 1e-3;
+          const labelClass = active
+            ? 'rounded-full bg-accentSoft/70 px-2 py-1 text-[10px] font-semibold uppercase text-accent shadow'
+            : 'rounded-full bg-white/80 px-2 py-1 text-[10px] font-semibold uppercase text-muted shadow';
           return (
             <label
               key={entry.dir}
@@ -89,8 +95,9 @@ export const DirectionalCompass = () => {
                 left: `calc(50% + ${offsetX}px)`,
                 top: `calc(50% + ${offsetY}px)`,
               }}
+              title={isDiagonal ? 'Averaged from adjacent cardinal weights' : undefined}
             >
-              <span className="rounded-full bg-white/80 px-2 py-1 text-[10px] font-semibold uppercase text-muted shadow">
+              <span className={labelClass}>
                 {entry.label}
               </span>
               <input
@@ -98,11 +105,16 @@ export const DirectionalCompass = () => {
                 step={0.5}
                 min={0}
                 max={10}
-                className="w-full rounded-full border border-border bg-white/95 px-2 py-1 text-center text-xs text-text shadow focus:border-accent focus:outline-none"
-                value={valueLookup[entry.dir].toFixed(1)}
+                className={`w-full rounded-full border bg-white/95 px-2 py-1 text-center text-xs text-text shadow focus:border-accent focus:outline-none ${
+                  isDiagonal ? 'border-dashed border-border/70 text-muted' : 'border-border'
+                }`}
+                value={value.toFixed(1)}
+                disabled={isDiagonal}
                 onChange={(event) => {
                   const next = Number(event.target.value);
-                  handleChange(entry.dir, Number.isNaN(next) ? 0 : next);
+                  if (!isDiagonal) {
+                    handleChange(entry.dir, Number.isNaN(next) ? 0 : next);
+                  }
                 }}
               />
             </label>

--- a/src/ui/DirectionalCompass.tsx
+++ b/src/ui/DirectionalCompass.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import type { DirKey } from '../types';
+import { useWorkspaceStore } from '../state';
+
+const DIRECTIONS: Array<{ dir: DirKey; angle: number; label: string }> = [
+  { dir: 'N', angle: -90, label: 'N' },
+  { dir: 'NE', angle: -45, label: 'NE' },
+  { dir: 'E', angle: 0, label: 'E' },
+  { dir: 'SE', angle: 45, label: 'SE' },
+  { dir: 'S', angle: 90, label: 'S' },
+  { dir: 'SW', angle: 135, label: 'SW' },
+  { dir: 'W', angle: 180, label: 'W' },
+  { dir: 'NW', angle: -135, label: 'NW' },
+];
+
+const radius = 70;
+
+export const DirectionalCompass = () => {
+  const defaults = useWorkspaceStore((state) => state.oxidationDefaults);
+  const updateDefaults = useWorkspaceStore((state) => state.updateOxidationDefaults);
+
+  const valueLookup = useMemo(() => {
+    const lookup: Record<DirKey, number> = {
+      N: 0,
+      NE: 0,
+      E: 0,
+      SE: 0,
+      S: 0,
+      SW: 0,
+      W: 0,
+      NW: 0,
+    };
+    defaults.thicknessByDirection.items.forEach((item) => {
+      lookup[item.dir] = item.valueUm;
+    });
+    return lookup;
+  }, [defaults.thicknessByDirection.items]);
+
+  const handleChange = (dir: DirKey, value: number) => {
+    const items = defaults.thicknessByDirection.items.map((item) =>
+      item.dir === dir ? { ...item, valueUm: value } : item,
+    );
+    updateDefaults({
+      thicknessByDirection: {
+        ...defaults.thicknessByDirection,
+        items,
+      },
+    });
+  };
+
+  return (
+    <div className="pointer-events-none absolute left-4 top-4 select-none">
+      <div className="relative flex h-40 w-40 items-center justify-center rounded-full border border-border bg-white/70 shadow-inner">
+        <div className="text-center text-[11px] font-semibold text-muted">
+          Directional weights
+          <div className="text-xs font-bold text-text">{defaults.thicknessByDirection.kappa.toFixed(1)} κ</div>
+        </div>
+        {DIRECTIONS.map((entry) => {
+          const radians = (entry.angle * Math.PI) / 180;
+          const offsetX = Math.cos(radians) * radius;
+          const offsetY = Math.sin(radians) * radius;
+          return (
+            <label
+              key={entry.dir}
+              className="pointer-events-auto absolute flex w-16 -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-1"
+              style={{
+                left: `calc(50% + ${offsetX}px)`,
+                top: `calc(50% + ${offsetY}px)`,
+              }}
+            >
+              <span className="rounded-full bg-white/80 px-2 py-1 text-[10px] font-semibold uppercase text-muted shadow">
+                {entry.label}
+              </span>
+              <input
+                type="number"
+                step={0.5}
+                className="w-full rounded-full border border-border bg-white/95 px-2 py-1 text-center text-xs text-text shadow focus:border-accent focus:outline-none"
+                value={valueLookup[entry.dir].toFixed(1)}
+                onChange={(event) => {
+                  const next = Number(event.target.value);
+                  handleChange(entry.dir, Number.isNaN(next) ? 0 : next);
+                }}
+              />
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/MeasurementPanel.tsx
+++ b/src/ui/MeasurementPanel.tsx
@@ -2,9 +2,9 @@ import { useWorkspaceStore } from '../state';
 
 export const MeasurementPanel = () => {
   const measurements = useWorkspaceStore((state) => state.measurements);
-  const clearProbes = useWorkspaceStore((state) => state.clearProbes);
   const setHeatmapVisible = useWorkspaceStore((state) => state.setHeatmapVisible);
   const setMeasurementSnapping = useWorkspaceStore((state) => state.setMeasurementSnapping);
+  const setPinnedProbe = useWorkspaceStore((state) => state.setPinnedProbe);
 
   return (
     <div className="panel flex flex-col gap-4 p-4">
@@ -27,33 +27,38 @@ export const MeasurementPanel = () => {
           onChange={(event) => setMeasurementSnapping(event.target.checked)}
         />
       </div>
-      <div className="rounded-2xl border border-dashed border-border/70 bg-white/50 p-3">
-        {measurements.history.length === 0 ? (
-          <div className="text-xs text-muted">No measurements recorded yet.</div>
+      <div className="rounded-2xl border border-dashed border-border/70 bg-white/60 p-3 text-xs text-muted">
+        {measurements.pinnedProbe ? (
+          <div className="flex flex-col gap-2 text-text">
+            <div className="flex items-center justify-between text-[11px] font-semibold">
+              <span>{measurements.pinnedProbe.distance.toFixed(2)} μm</span>
+              <span>{measurements.pinnedProbe.angleDeg.toFixed(1)}°</span>
+            </div>
+            <div className="flex justify-between text-[10px] uppercase tracking-widest text-muted">
+              <span>
+                A ({measurements.pinnedProbe.a.x.toFixed(0)} μm,{' '}
+                {measurements.pinnedProbe.a.y.toFixed(0)} μm)
+              </span>
+              <span>
+                B ({measurements.pinnedProbe.b.x.toFixed(0)} μm,{' '}
+                {measurements.pinnedProbe.b.y.toFixed(0)} μm)
+              </span>
+            </div>
+          </div>
         ) : (
-          <ul className="flex flex-col gap-2 text-xs text-muted">
-            {measurements.history.map((probe) => (
-              <li key={probe.id} className="flex flex-col gap-1 rounded-xl bg-accentSoft/40 px-3 py-2">
-                <div className="flex items-center justify-between text-[11px] font-semibold text-text">
-                  <span>{probe.distance.toFixed(2)} μm</span>
-                  <span>{probe.angleDeg.toFixed(1)}°</span>
-                </div>
-                <div className="flex justify-between text-[10px] uppercase tracking-widest">
-                  <span>A ({probe.a.x.toFixed(0)} μm, {probe.a.y.toFixed(0)} μm)</span>
-                  <span>B ({probe.b.x.toFixed(0)} μm, {probe.b.y.toFixed(0)} μm)</span>
-                </div>
-              </li>
-            ))}
-          </ul>
+          <div className="text-xs">
+            Hover the outer contour to preview oxide thickness. Click to pin the current normal
+            measurement.
+          </div>
         )}
       </div>
       <button
         type="button"
         className="toolbar-button"
-        onClick={() => clearProbes()}
-        disabled={measurements.history.length === 0}
+        onClick={() => setPinnedProbe(null)}
+        disabled={!measurements.pinnedProbe}
       >
-        Clear history
+        Clear pinned measurement
       </button>
     </div>
   );

--- a/src/ui/MeasurementPanel.tsx
+++ b/src/ui/MeasurementPanel.tsx
@@ -35,12 +35,12 @@ export const MeasurementPanel = () => {
             {measurements.history.map((probe) => (
               <li key={probe.id} className="flex flex-col gap-1 rounded-xl bg-accentSoft/40 px-3 py-2">
                 <div className="flex items-center justify-between text-[11px] font-semibold text-text">
-                  <span>{probe.distance.toFixed(2)} px</span>
+                  <span>{probe.distance.toFixed(2)} μm</span>
                   <span>{probe.angleDeg.toFixed(1)}°</span>
                 </div>
                 <div className="flex justify-between text-[10px] uppercase tracking-widest">
-                  <span>A ({probe.a.x.toFixed(0)}, {probe.a.y.toFixed(0)})</span>
-                  <span>B ({probe.b.x.toFixed(0)}, {probe.b.y.toFixed(0)})</span>
+                  <span>A ({probe.a.x.toFixed(0)} μm, {probe.a.y.toFixed(0)} μm)</span>
+                  <span>B ({probe.b.x.toFixed(0)} μm, {probe.b.y.toFixed(0)} μm)</span>
                 </div>
               </li>
             ))}

--- a/src/ui/OxidationPanel.tsx
+++ b/src/ui/OxidationPanel.tsx
@@ -1,25 +1,13 @@
 import { useMemo } from 'react';
-import type { DirKey } from '../types';
 import { useWorkspaceStore } from '../state';
 
 const formatValue = (value: number) => value.toFixed(1);
 
-const DIRECTION_LABELS: Record<DirKey, string> = {
-  N: 'North',
-  NE: 'North-East',
-  E: 'East',
-  SE: 'South-East',
-  S: 'South',
-  SW: 'South-West',
-  W: 'West',
-  NW: 'North-West',
-};
-
-const DIRECTION_ORDER: DirKey[] = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
-
 export const OxidationPanel = () => {
   const defaults = useWorkspaceStore((state) => state.oxidationDefaults);
   const updateDefaults = useWorkspaceStore((state) => state.updateOxidationDefaults);
+  const oxidationVisible = useWorkspaceStore((state) => state.oxidationVisible);
+  const toggleVisible = useWorkspaceStore((state) => state.toggleOxidationVisible);
 
   const directionValues = useMemo(
     () => defaults.thicknessByDirection.items.map((item) => item.valueUm),
@@ -41,21 +29,18 @@ export const OxidationPanel = () => {
     [defaults, range.max, range.min],
   );
 
-  const updateDirection = (dir: DirKey, value: number) => {
-    const items = defaults.thicknessByDirection.items.map((item) =>
-      item.dir === dir ? { ...item, valueUm: value } : item,
-    );
-    updateDefaults({
-      thicknessByDirection: {
-        ...defaults.thicknessByDirection,
-        items,
-      },
-    });
-  };
-
   return (
     <div className="panel flex flex-col gap-4 p-4">
       <div className="section-title">Oxidation</div>
+      <label className="flex items-center justify-between text-xs font-medium text-muted">
+        <span>Show oxide preview</span>
+        <input
+          type="checkbox"
+          className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
+          checked={oxidationVisible}
+          onChange={(event) => toggleVisible(event.target.checked)}
+        />
+      </label>
       <div className="grid grid-cols-3 gap-3 text-xs text-muted">
         {preview.map((item) => (
           <div key={item.label} className="rounded-xl bg-accentSoft/60 px-3 py-2 text-center text-[11px]">
@@ -105,22 +90,9 @@ export const OxidationPanel = () => {
           }
         />
       </div>
-      <div className="grid grid-cols-2 gap-3 text-sm">
-        {DIRECTION_ORDER.map((dir) => {
-          const current = defaults.thicknessByDirection.items.find((item) => item.dir === dir);
-          const value = current?.valueUm ?? 0;
-          return (
-            <LabeledSlider
-              key={dir}
-              label={`${DIRECTION_LABELS[dir]} (${dir})`}
-              min={-25}
-              max={25}
-              step={0.5}
-              value={value}
-              onChange={(v) => updateDirection(dir, v)}
-            />
-          );
-        })}
+      <div className="rounded-2xl border border-dashed border-border/70 bg-white/60 p-3 text-xs text-muted">
+        Directional μm offsets can be edited via the circular compass overlay on the canvas. Tap a cardinal label there to input
+        values directly.
       </div>
       <label className="flex items-center gap-2 text-xs font-medium text-muted">
         <input

--- a/src/ui/OxidationPanel.tsx
+++ b/src/ui/OxidationPanel.tsx
@@ -1,19 +1,57 @@
 import { useMemo } from 'react';
+import type { DirKey } from '../types';
 import { useWorkspaceStore } from '../state';
 
 const formatValue = (value: number) => value.toFixed(1);
 
+const DIRECTION_LABELS: Record<DirKey, string> = {
+  N: 'North',
+  NE: 'North-East',
+  E: 'East',
+  SE: 'South-East',
+  S: 'South',
+  SW: 'South-West',
+  W: 'West',
+  NW: 'North-West',
+};
+
+const DIRECTION_ORDER: DirKey[] = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+
 export const OxidationPanel = () => {
   const defaults = useWorkspaceStore((state) => state.oxidationDefaults);
   const updateDefaults = useWorkspaceStore((state) => state.updateOxidationDefaults);
-  const preview = useMemo(
-    () => [
-      { label: 'Kernel', value: `${formatValue(defaults.kernelWidth)} px` },
-      { label: 'Target', value: `${formatValue(defaults.targetThickness)} nm` },
-      { label: 'Base', value: `${formatValue(defaults.baseThickness)} nm` },
-    ],
+
+  const directionValues = useMemo(
+    () => defaults.thicknessByDirection.items.map((item) => item.valueUm),
     [defaults],
   );
+
+  const range = useMemo(() => {
+    const min = Math.min(...directionValues);
+    const max = Math.max(...directionValues);
+    return { min, max };
+  }, [directionValues]);
+
+  const preview = useMemo(
+    () => [
+      { label: 'Uniform', value: `${formatValue(defaults.thicknessUniformUm)} μm` },
+      { label: 'κ', value: formatValue(defaults.thicknessByDirection.kappa) },
+      { label: 'Δ range', value: `${formatValue(range.max - range.min)} μm` },
+    ],
+    [defaults, range.max, range.min],
+  );
+
+  const updateDirection = (dir: DirKey, value: number) => {
+    const items = defaults.thicknessByDirection.items.map((item) =>
+      item.dir === dir ? { ...item, valueUm: value } : item,
+    );
+    updateDefaults({
+      thicknessByDirection: {
+        ...defaults.thicknessByDirection,
+        items,
+      },
+    });
+  };
 
   return (
     <div className="panel flex flex-col gap-4 p-4">
@@ -28,28 +66,12 @@ export const OxidationPanel = () => {
       </div>
       <div className="flex flex-col gap-3 text-sm">
         <LabeledSlider
-          label="Kernel width"
-          min={4}
-          max={48}
-          step={0.5}
-          value={defaults.kernelWidth}
-          onChange={(value) => updateDefaults({ kernelWidth: value })}
-        />
-        <LabeledSlider
-          label="Target thickness"
-          min={1}
-          max={25}
-          step={0.5}
-          value={defaults.targetThickness}
-          onChange={(value) => updateDefaults({ targetThickness: value })}
-        />
-        <LabeledSlider
-          label="Base thickness"
+          label="Uniform thickness"
           min={0}
-          max={defaults.targetThickness}
+          max={50}
           step={0.5}
-          value={defaults.baseThickness}
-          onChange={(value) => updateDefaults({ baseThickness: value })}
+          value={defaults.thicknessUniformUm}
+          onChange={(value) => updateDefaults({ thicknessUniformUm: value })}
         />
         <LabeledSlider
           label="Smoothing strength"
@@ -68,13 +90,37 @@ export const OxidationPanel = () => {
           onChange={(value) => updateDefaults({ smoothingIterations: Math.round(value) })}
         />
         <LabeledSlider
-          label="Von Mises κ"
+          label="Directional κ"
           min={1}
           max={12}
-          step={0.5}
-          value={defaults.vonMisesKappa}
-          onChange={(value) => updateDefaults({ vonMisesKappa: value })}
+          step={0.25}
+          value={defaults.thicknessByDirection.kappa}
+          onChange={(value) =>
+            updateDefaults({
+              thicknessByDirection: {
+                ...defaults.thicknessByDirection,
+                kappa: value,
+              },
+            })
+          }
         />
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        {DIRECTION_ORDER.map((dir) => {
+          const current = defaults.thicknessByDirection.items.find((item) => item.dir === dir);
+          const value = current?.valueUm ?? 0;
+          return (
+            <LabeledSlider
+              key={dir}
+              label={`${DIRECTION_LABELS[dir]} (${dir})`}
+              min={-25}
+              max={25}
+              step={0.5}
+              value={value}
+              onChange={(v) => updateDirection(dir, v)}
+            />
+          );
+        })}
       </div>
       <label className="flex items-center gap-2 text-xs font-medium text-muted">
         <input

--- a/src/ui/ScenePanel.tsx
+++ b/src/ui/ScenePanel.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { useWorkspaceStore } from '../state';
+import { createId } from '../utils/ids';
+import { createCircleNodes } from '../utils/presets';
+
+export const ScenePanel = () => {
+  const selectedPathIds = useWorkspaceStore((state) => state.selectedPathIds);
+  const paths = useWorkspaceStore((state) => state.paths);
+  const saveShape = useWorkspaceStore((state) => state.saveShapeToLibrary);
+  const removeShape = useWorkspaceStore((state) => state.removeShapeFromLibrary);
+  const renameShape = useWorkspaceStore((state) => state.renameShapeInLibrary);
+  const loadShape = useWorkspaceStore((state) => state.loadShapeFromLibrary);
+  const resetScene = useWorkspaceStore((state) => state.resetScene);
+  const removePath = useWorkspaceStore((state) => state.removePath);
+  const addPath = useWorkspaceStore((state) => state.addPath);
+  const library = useWorkspaceStore((state) => state.library);
+  const [shapeName, setShapeName] = useState('');
+  const [renameDrafts, setRenameDrafts] = useState<Record<string, string>>({});
+
+  const selectedPath = paths.find((path) => path.meta.id === selectedPathIds[0]);
+  const handleSave = () => {
+    if (!selectedPath) return;
+    saveShape(selectedPath.meta.id, shapeName || selectedPath.meta.name);
+    setShapeName('');
+  };
+
+  const handleRenameCommit = (id: string) => {
+    const draft = renameDrafts[id];
+    if (draft !== undefined) {
+      renameShape(id, draft);
+    }
+  };
+
+  return (
+    <div className="panel flex flex-col gap-4 p-4 text-xs text-muted">
+      <div className="section-title">Scene</div>
+      <div className="flex flex-col gap-2 text-xs">
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] uppercase tracking-wide text-muted">Shape name</span>
+          <input
+            type="text"
+            value={shapeName}
+            onChange={(event) => setShapeName(event.target.value)}
+            placeholder={selectedPath ? selectedPath.meta.name : 'Select a path'}
+            className="rounded-xl border border-border bg-white/80 px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
+          />
+        </label>
+        <button
+          type="button"
+          className="toolbar-button"
+          onClick={handleSave}
+          disabled={!selectedPath}
+        >
+          Save shape to library
+        </button>
+        <button
+          type="button"
+          className="toolbar-button"
+          onClick={() => selectedPath && removePath(selectedPath.meta.id)}
+          disabled={!selectedPath}
+        >
+          Delete selected path
+        </button>
+        <button
+          type="button"
+          className="toolbar-button"
+          onClick={() => {
+            resetScene();
+            setShapeName('');
+          }}
+        >
+          Reset canvas
+        </button>
+        <button
+          type="button"
+          className="toolbar-button"
+          onClick={() =>
+            addPath(createCircleNodes({ x: 360, y: 320 }, 180), {
+              meta: {
+                id: createId('path'),
+                name: 'Reference circle',
+                closed: true,
+                visible: true,
+                locked: false,
+                color: '#2563eb',
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+              },
+            })
+          }
+        >
+          Add reference circle
+        </button>
+      </div>
+      <div className="rounded-2xl border border-dashed border-border/70 bg-white/60 p-3">
+        {library.length === 0 ? (
+          <div className="text-xs">Saved shapes will appear here. Capture any contour to reuse it later.</div>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {library.map((shape) => (
+              <li key={shape.id} className="flex flex-col gap-2 rounded-xl bg-white/80 p-3 shadow-sm">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    defaultValue={shape.name}
+                    onChange={(event) =>
+                      setRenameDrafts((drafts) => ({ ...drafts, [shape.id]: event.target.value }))
+                    }
+                    onBlur={() => handleRenameCommit(shape.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        handleRenameCommit(shape.id);
+                        event.currentTarget.blur();
+                      }
+                    }}
+                    className="flex-1 rounded-lg border border-border bg-white/80 px-2 py-1 text-sm text-text focus:border-accent focus:outline-none"
+                  />
+                  <button
+                    type="button"
+                    className="rounded-lg border border-accent px-2 py-1 text-[11px] font-semibold text-accent hover:bg-accent/10"
+                    onClick={() => loadShape(shape.id)}
+                  >
+                    Load
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-lg border border-border px-2 py-1 text-[11px] text-muted hover:bg-border/20"
+                    onClick={() => removeShape(shape.id)}
+                  >
+                    Delete
+                  </button>
+                </div>
+                <div className="flex justify-between text-[10px] uppercase tracking-widest text-muted">
+                  <span>{shape.nodes.length} pts</span>
+                  <span>Saved {new Date(shape.updatedAt).toLocaleDateString()}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/ScenePanel.tsx
+++ b/src/ui/ScenePanel.tsx
@@ -75,7 +75,7 @@ export const ScenePanel = () => {
           type="button"
           className="toolbar-button"
           onClick={() =>
-            addPath(createCircleNodes({ x: 360, y: 320 }, 180), {
+            addPath(createCircleNodes({ x: 25, y: 25 }, 18), {
               meta: {
                 id: createId('path'),
                 name: 'Reference circle',

--- a/src/ui/useKeyboardShortcuts.ts
+++ b/src/ui/useKeyboardShortcuts.ts
@@ -14,6 +14,7 @@ export const useKeyboardShortcuts = () => {
   const setActiveTool = useWorkspaceStore((state) => state.setActiveTool);
   const undo = useWorkspaceStore((state) => state.undo);
   const redo = useWorkspaceStore((state) => state.redo);
+  const deleteSelectedNodes = useWorkspaceStore((state) => state.deleteSelectedNodes);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -34,6 +35,10 @@ export const useKeyboardShortcuts = () => {
         event.preventDefault();
         setActiveTool(keyMap[key]);
       }
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        event.preventDefault();
+        deleteSelectedNodes();
+      }
       if (event.code === 'Space') {
         event.preventDefault();
         setActiveTool('pan');
@@ -41,5 +46,5 @@ export const useKeyboardShortcuts = () => {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [redo, setActiveTool, undo]);
+  }, [deleteSelectedNodes, redo, setActiveTool, undo]);
 };

--- a/src/utils/presets.ts
+++ b/src/utils/presets.ts
@@ -1,0 +1,32 @@
+import { createId } from './ids';
+import type { PathNode } from '../types';
+
+export const createCircleNodes = (center: { x: number; y: number }, radius: number): PathNode[] => {
+  const k = radius * 0.5522847498307936;
+  return [
+    {
+      id: createId('node'),
+      point: { x: center.x + radius, y: center.y },
+      handleIn: { x: center.x + radius, y: center.y + k },
+      handleOut: { x: center.x + radius, y: center.y - k },
+    },
+    {
+      id: createId('node'),
+      point: { x: center.x, y: center.y - radius },
+      handleIn: { x: center.x + k, y: center.y - radius },
+      handleOut: { x: center.x - k, y: center.y - radius },
+    },
+    {
+      id: createId('node'),
+      point: { x: center.x - radius, y: center.y },
+      handleIn: { x: center.x - radius, y: center.y - k },
+      handleOut: { x: center.x - radius, y: center.y + k },
+    },
+    {
+      id: createId('node'),
+      point: { x: center.x, y: center.y + radius },
+      handleIn: { x: center.x - k, y: center.y + radius },
+      handleOut: { x: center.x + k, y: center.y + radius },
+    },
+  ];
+};


### PR DESCRIPTION
## Summary
- add data model support for directional oxidation weights and cloning helpers
- evaluate contour thickness with von Mises weighting across compass directions
- refresh the oxidation settings panel with uniform/kappa controls and eight direction sliders

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2bf4018388324875b22f061656e05