### PR TITLE
Rewrite oxidation inset alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,9 @@ Think of this file as the living design history.  Out-of-date instructions cause
 ## 2024-06-02 — Clipper offset execution fix
 
 - `computeOffset` must call `ClipperOffset.Execute` with an output array to avoid mutating a numeric delta (the JS port mutates the array argument). Reuse the shared helper and don’t reintroduce the old single-argument form—it hard-crashes the app on startup.
+
+## 2025-02-14 — Multi-loop oxidation alignment rewrite
+
+- `deriveInnerGeometry` now ray-marches each outer sample toward the Clipper inset so multi-lobed baselines keep their own sample groups. Do not short-circuit this cast; directional extras depend on the per-sample hit result.
+- Inner candidates are cleaned per inset loop and resampled back onto the original sample indices. If you tweak this, make sure `innerSamples[i]` still pairs with `samples[i]` even when inset polygons split apart.
+- The grouped cleaning step may return multiple loops—keep assigning anchors by proximity so stray spokes don’t jump across gaps. If you add new filters, preserve this grouping.


### PR DESCRIPTION
## Summary
- rewrite `deriveInnerGeometry` to ray-cast onto every inset loop, group samples by hit polygon, and align cleaned loops back to the outer contour ordering
- keep multi-loop oxidation stable by resampling grouped anchors before filling `innerSamples`
- document the new multi-loop processing rules in `AGENTS.md`

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3397c36848324b1a29b2e5be9a8f2