### PR TITLE
Raycast inner oxide enforcement onto dense envelope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,8 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - `deriveInnerGeometry` now samples an SDF grid of the outer loop (via `sdf-polygon-2d`) and extracts the zero contour of `distance - thickness(angle)` using `marching-squares`. This iso-contour seeds the inner loop prior to smoothing/resampling—keep the march in place so directional weight tweaks immediately affect the field.
 - Expand the sampled bounds by the maximum requested thickness plus a small margin tied to `thicknessOptions.resolution`; otherwise the iso loop can clip at the grid edge.
 - The marched contour is still re-aligned to the outer samples and pushed through the minimum-thickness raycast. Preserve this enforcement so measurement probes honour the configured oxide floor even if the iso field under-shoots in tight corners.
+
+## 2025-10-19 — SDF outer loop sanitisation
+
+- `deriveInnerGeometry` strips duplicated closing samples and sequential near-duplicates from the outer loop before instantiating `polygonSdf`. Leave this guard intact; zero-length edges from duplicate samples trigger NaNs inside the SDF implementation.
+- When sampling the scalar field, non-finite evaluations are clamped to the uniform-thickness floor so the marching-squares pass keeps running instead of crashing the app.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,3 +120,9 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - `deriveInnerGeometry` now seeds the inner loop from a Clipper “round” inset built with the uniform thickness before re-aligning samples. Keep the `computeOffset(..., { delta: -uniformThickness })` call so sharp corners render as circular fillets instead of collapsing into triangles.
 - The inset polygon only serves as the projection reference—the final per-sample points are still obtained by raycasting along each inward normal and clamping to at least the requested (uniform + directional) thickness. Do not remove the `enforceMinimumOffset` raycast.
 - Cleaning runs on the projected loop itself; if it self-intersects we resample the dominant polygon back onto the sample indices before re-projecting. Preserve this ordering so measurement probes stay paired with their outer samples.
+
+## 2025-10-18 — SDF iso-contour reconstruction
+
+- `deriveInnerGeometry` now samples an SDF grid of the outer loop (via `sdf-polygon-2d`) and extracts the zero contour of `distance - thickness(angle)` using `marching-squares`. This iso-contour seeds the inner loop prior to smoothing/resampling—keep the march in place so directional weight tweaks immediately affect the field.
+- Expand the sampled bounds by the maximum requested thickness plus a small margin tied to `thicknessOptions.resolution`; otherwise the iso loop can clip at the grid edge.
+- The marched contour is still re-aligned to the outer samples and pushed through the minimum-thickness raycast. Preserve this enforcement so measurement probes honour the configured oxide floor even if the iso field under-shoots in tight corners.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,31 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - `deriveInnerGeometry` now builds the oxide interior using a variable-radius power diagram instead of rasterised SDF marching squares. Each boundary sample contributes a circle with its local thickness; visible arcs define the offset envelope.
 - The helper filters arcs to the inward half-space so compass headings (“N”, “E”, …) map to the expected directions after evaluating normals.
 - A small Laplacian smoothing pass post-processes the sampled loop to remove stair-steps before cleaning/resampling. Preserve this order if you refine the algorithm.
+
+## 2025-10-11 — Normal orientation & adaptive oxide resolution
+
+- `recomputeNormals` now flips averaged normals that point inward on closed loops using a centroid alignment check. Do not remove this guard—directional weights assume outward-facing normals.
+- The compass defaults map `E/N/W/S` to `0°/90°/180°/270°` so UI spokes match world-space directions. Keep this ordering when seeding new headings.
+- `ThicknessOptions` gained an optional `resolution` that defaults to `min(0.5, uniformThickness / 4)`. `deriveInnerGeometry` uses it for cleaning tolerance and picks between one or two Laplacian smoothing iterations via `laplacianSmooth(..., { closed: true })`.
+
+## 2025-10-12 — Oxide inner loop fidelity guard
+
+- `deriveInnerGeometry` now aligns the smoothed candidate loop back to the fallback normal projection before any cleaning. Only when the loop self-intersects do we route it through `cleanAndSimplifyPolygons`; otherwise we keep the full sample count so the inner contour mirrors the outer geometry.
+- The self-intersection test treats adjacent segments as shared vertices—don’t reuse it for open polylines without rethinking the guard.
+
+## 2025-10-13 — Normal-locked oxide floor
+
+- `recomputeNormals` now derives tangents from central differences (with optional smoothing) and normalises per-sample so normals stay perpendicular to the actual path, even through sharp corners. Keep this routine if you tweak sampling—directional weights assume normals never skew off their spokes.
+- `deriveInnerGeometry` reprojects all candidates back onto each sample’s inward normal after smoothing/cleaning, clamping travel to at least the requested thickness (uniform + compass weight). Any future adjustments must preserve this minimum-distance enforcement so oxide thickness never drops below the configured floor.
+
+## 2025-10-14 — Arc-sampled oxide envelope
+
+- `deriveInnerGeometry` now builds a dense envelope by sampling the visible arcs of each per-sample oxidation circle (minimum six points per segment) before resampling back to the original sample count. Preserve this arc sampling when tuning offsets so the inner contour keeps circular curvature instead of collapsing to straight chords.
+- The dense arc cloud is cleaned separately and exposed through `innerPolygons`; reuse the `closedDenseLoop` helper when exporting or debugging to avoid reintroducing duplicate closing vertices.
+- Arc sampling depends on the outer loop orientation; if you change how samples are ordered, recompute the `orientationSign` in lock-step so arc traversal stays consistent.
+
+## 2025-10-15 — Normal ray re-projection
+
+- When enforcing the minimum oxide thickness, project each sample along its inward normal until it intersects the dense arc envelope. This raycast distance replaces the old dot-product clamp so sharp corners expand smoothly instead of collapsing to straight chords.
+- Keep the polygon reference (`projectionLoop`) in sync with the dense envelope you intend to visualise; the ray projection assumes the polygon is closed and non-degenerate.
+- Falling back to the previous per-sample candidate is still allowed, but only after a raycast fails—don’t remove the guard, it maintains backwards compatibility for open paths and degenerate normals.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,8 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - When enforcing the minimum oxide thickness, project each sample along its inward normal until it intersects the dense arc envelope. This raycast distance replaces the old dot-product clamp so sharp corners expand smoothly instead of collapsing to straight chords.
 - Keep the polygon reference (`projectionLoop`) in sync with the dense envelope you intend to visualise; the ray projection assumes the polygon is closed and non-degenerate.
 - Falling back to the previous per-sample candidate is still allowed, but only after a raycast fails—don’t remove the guard, it maintains backwards compatibility for open paths and degenerate normals.
+
+## 2025-10-16 — Disc-envelope sampling fix
+
+- `deriveInnerGeometry` samples each oxidation circle directly at adaptive angular steps, discarding directions that point outward or become occluded by a neighbour’s disc. Preserve this sampling so the inner contour always inherits circular curvature from the contributing site instead of collapsing to chords.
+- When a sample contributes no visible arc, we fall back to casting its inward normal through the disc envelope. Keep this behaviour so occluded spans still align with the final cleaned polygon before the minimum-thickness clamp runs.

--- a/src/geometry/normals.ts
+++ b/src/geometry/normals.ts
@@ -1,20 +1,114 @@
 import type { SamplePoint } from '../types';
-import { add, normalize } from '../utils/math';
+import { add, normalize, scale, sub } from '../utils/math';
 
-export const recomputeNormals = (samples: SamplePoint[], window = 2): SamplePoint[] => {
+const isZero = (vector: { x: number; y: number }): boolean =>
+  Math.abs(vector.x) <= 1e-6 && Math.abs(vector.y) <= 1e-6;
+
+const normaliseTangent = (candidate: { x: number; y: number }): { x: number; y: number } => {
+  const normalised = normalize(candidate);
+  if (!isZero(normalised)) {
+    return normalised;
+  }
+  return { x: 1, y: 0 };
+};
+
+export const recomputeNormals = (samples: SamplePoint[], window = 1): SamplePoint[] => {
   if (!samples.length) return samples;
   const result = samples.map((sample) => ({ ...sample }));
-  for (let i = 0; i < samples.length; i += 1) {
-    const start = Math.max(0, i - window);
-    const end = Math.min(samples.length - 1, i + window);
-    let tangent = { x: 0, y: 0 };
-    for (let j = start; j <= end; j += 1) {
-      tangent = add(tangent, samples[j].tangent);
-    }
-    const averaged = normalize(tangent);
-    result[i].tangent = averaged;
-    result[i].normal = { x: -averaged.y, y: averaged.x };
+
+  if (samples.length === 1) {
+    const tangent = normaliseTangent(samples[0].tangent);
+    result[0].tangent = tangent;
+    result[0].normal = { x: -tangent.y, y: tangent.x };
+    return result;
   }
+
+  const start = samples[0].position;
+  const end = samples[samples.length - 1].position;
+  const closingDistanceSq = (start.x - end.x) ** 2 + (start.y - end.y) ** 2;
+  const isClosed = closingDistanceSq < 1e-6;
+
+  const baseTangents = samples.map((sample, index) => {
+    if (!isClosed) {
+      if (index === 0 && samples.length > 1) {
+        const forward = normalize(sub(samples[1].position, sample.position));
+        if (!isZero(forward)) return forward;
+      }
+      if (index === samples.length - 1 && samples.length > 1) {
+        const backward = normalize(sub(sample.position, samples[index - 1].position));
+        if (!isZero(backward)) return backward;
+      }
+    }
+
+    const prevIndex = index === 0 ? (isClosed ? samples.length - 1 : index) : index - 1;
+    const nextIndex = index === samples.length - 1 ? (isClosed ? 0 : index) : index + 1;
+
+    let delta = { x: 0, y: 0 };
+    if (prevIndex !== index && nextIndex !== index) {
+      delta = sub(samples[nextIndex].position, samples[prevIndex].position);
+    } else if (nextIndex !== index) {
+      delta = sub(samples[nextIndex].position, sample.position);
+    } else if (prevIndex !== index) {
+      delta = sub(sample.position, samples[prevIndex].position);
+    }
+
+    if (!isZero(delta)) {
+      return normaliseTangent(delta);
+    }
+
+    const fallback = normaliseTangent(sample.tangent);
+    return fallback;
+  });
+
+  const smoothWindow = Math.max(0, Math.floor(window));
+
+  for (let i = 0; i < samples.length; i += 1) {
+    let accumulated = { x: 0, y: 0 };
+    let count = 0;
+    for (let offset = -smoothWindow; offset <= smoothWindow; offset += 1) {
+      const index = i + offset;
+      if (index < 0 || index >= samples.length) continue;
+      accumulated = add(accumulated, baseTangents[index]);
+      count += 1;
+    }
+
+    let tangent = count > 0 ? normalize(accumulated) : baseTangents[i];
+    if (isZero(tangent)) {
+      tangent = baseTangents[i];
+    }
+
+    if (isZero(tangent)) {
+      tangent = { x: 1, y: 0 };
+    }
+
+    result[i].tangent = tangent;
+    result[i].normal = { x: -tangent.y, y: tangent.x };
+  }
+
+  if (!isClosed) {
+    return result;
+  }
+
+  const centroid = scale(
+    samples.reduce((acc, sample) => add(acc, sample.position), { x: 0, y: 0 }),
+    1 / samples.length,
+  );
+
+  let normalAlignment = 0;
+  for (const sample of result) {
+    const toSample = {
+      x: sample.position.x - centroid.x,
+      y: sample.position.y - centroid.y,
+    };
+    normalAlignment += sample.normal.x * toSample.x + sample.normal.y * toSample.y;
+  }
+
+  if (normalAlignment < 0) {
+    for (const sample of result) {
+      sample.normal = { x: -sample.normal.x, y: -sample.normal.y };
+    }
+  }
+
   return result;
 };
 

--- a/src/geometry/smoothing.ts
+++ b/src/geometry/smoothing.ts
@@ -28,14 +28,26 @@ export const smoothSamples = (
   return result;
 };
 
-export const laplacianSmooth = (points: Vec2[], alpha: number, iterations: number): Vec2[] => {
+interface LaplacianOptions {
+  closed?: boolean;
+}
+
+export const laplacianSmooth = (
+  points: Vec2[],
+  alpha: number,
+  iterations: number,
+  options: LaplacianOptions = {},
+): Vec2[] => {
   if (points.length < 3) return points;
+  const { closed = false } = options;
   let result = points.map((p) => ({ ...p }));
   for (let iter = 0; iter < iterations; iter += 1) {
     const next = result.map((point, i) => {
-      if (i === 0 || i === result.length - 1) return point;
-      const prev = result[i - 1];
-      const nextPoint = result[i + 1];
+      if (!closed && (i === 0 || i === result.length - 1)) return point;
+      const prevIndex = i === 0 ? (closed ? result.length - 1 : i) : i - 1;
+      const nextIndex = i === result.length - 1 ? (closed ? 0 : i) : i + 1;
+      const prev = result[prevIndex];
+      const nextPoint = result[nextIndex];
       const average = scale(add(prev, nextPoint), 0.5);
       return add(point, scale(sub(average, point), alpha));
     });

--- a/src/geometry/thickness.ts
+++ b/src/geometry/thickness.ts
@@ -5,6 +5,7 @@ export interface ThicknessOptions {
   weights: DirectionWeight[];
   mirrorSymmetry?: boolean;
   progress?: number;
+  resolution?: number;
 }
 
 interface NormalizedWeight {


### PR DESCRIPTION
## Summary
- project each sample's inward normal onto the dense arc envelope to measure oxide travel before applying the minimum-thickness clamp so sharp corners stay rounded
- reuse the cleaned dense loop (or selected primary polygon) while reprojecting fallback samples to keep the enforced offsets aligned with the visual envelope
- document the new normal ray projection workflow and guards in the agent handbook for future contributors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44526a9488324a6f913800394fa1a