### PR TITLE
Align open-path dense envelopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,3 +159,8 @@ Think of this file as the living design history.  Out-of-date instructions cause
 
 - When fanning contour copies along open segments, only consider candidates whose path parameter overlaps the sample’s neighbourhood so remote copies can’t tug the oxide inward from the opposite side of the trace.
 - Keep open paths from auto-snapping closed when their endpoints meet; designers must explicitly close loops elsewhere if needed.
+
+## 2025-10-24 — Tangential guard for replicated open envelopes
+
+- Open-path oxidation now rejects replicated contour hits whose sideways drift exceeds ~10 % of their inward travel (with a small absolute floor) before picking the innermost sample. This keeps the preview from folding back across corners when neighbouring segments overlap.
+- When comparing candidates with similar inward travel, prefer the one with the smaller tangential component so the resulting polyline hugs the expected side of the trace.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Think of this file as the living design history.  Out-of-date instructions cause
 
 - Oxidation defaults and the active selection stay in lock-step.  Use `updateSelectedOxidation` when adjusting per-path values so the geometry pipeline re-runs and history snapshots remain consistent.
 - Segment toggling (line ↔︎ Bézier) is handled in the store via `toggleSegmentCurve`.  Any future editing affordances should reuse that action to keep mirrored/closed path invariants intact.
-- Path endpoints auto-close when they approach within ~4 μm and mirror snapping pins points to the configured axes—avoid bypassing `mergeEndpointsIfClose` or `applyMirrorSnapping` when mutating node arrays.
+- Path endpoints now stay open even when their distance falls below ~4 μm so designers can sketch tight U-turns without the contour snapping shut. Leave `mergeEndpointsIfClose` in place to keep this guard and continue to respect mirror snapping for axis alignment.
 - Inner oxidation silhouettes are now cleaned with Clipper before resampling; if you extend the offset logic, feed new contours back through `cleanAndSimplifyPolygons` so ribbons never self-intersect.
 - UI and models now clamp oxide inputs to ≤ 10 μm.  Preserve `MAX_THICKNESS_UM` when introducing new entry points or validation.
 
@@ -154,3 +154,8 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Open-path envelopes now replicate the global oxidation contour (40 angular samples) along each segment (10 placements per span), keeping only the most inward intersections per sample. Skip smoothing and do not reuse the arc-union fallback.
 - Only expose the innermost line of the oxide preview for open paths—`polygons` stay empty so the renderer no longer shades the ribbon.
 - Canvas rendering removed the gradient ribbon and dashed outer stroke; draw both contours as solid lines to match the single-sided spec.
+
+## 2025-10-23 — Local open-contour filtering & no auto-closing
+
+- When fanning contour copies along open segments, only consider candidates whose path parameter overlaps the sample’s neighbourhood so remote copies can’t tug the oxide inward from the opposite side of the trace.
+- Keep open paths from auto-snapping closed when their endpoints meet; designers must explicitly close loops elsewhere if needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This project implements **Oxid Designer**, a Vite + React + TypeScript workbench
 - The oxidation pipeline now derives the inner contour by first carving a uniform baseline offset with Clipper and then layering per-heading expansions along the outward normals.  Preserve this sequence inside `runGeometryPipeline()` so the oxide shell always honours the configured minimum thickness.
 - Canvas interactions must respect the active tool in state (`select`, `pen`, `edit`, `measure`, etc.).  Selections, node manipulation, and measurement overlays are driven from `CanvasViewport` using store actions.
 - Units inside the UI are **micrometres (μm)**.  Never reintroduce raw pixel units in UI strings or overlays.
-- The oxide preview is drawn inside the canvas renderer.  Do not remove the gradient fill between the external contour and the oxidised inner contour unless a spec change requires it.
+- The oxide preview is drawn inside the canvas renderer.  The ribbon gradient and dashed outer stroke were retired in favour of a single-line preview—don’t restore them unless a future spec calls for it.
 
 ## Documentation Discipline
 
@@ -148,3 +148,9 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - `deriveInnerGeometry` now resamples open-path `denseLoop` results back to the sampled resolution before aligning with `alignLoop`. After alignment, immediately call `enforceMinimumOffset` so tangential drift still respects the configured oxide floor.
 - A helper `resampleOpenPolyline` lives beside `resampleClosedPolygon`. Reuse it when you need evenly spaced open-line samples.
 - Added `docs/regressions/asymmetric-open-oxidation.svg` as a quick visual check for asymmetric envelopes on open paths. Keep it updated whenever the open-loop offset behaviour changes.
+
+## 2025-10-22 — Single-sided replicated oxide contour
+
+- Open-path envelopes now replicate the global oxidation contour (40 angular samples) along each segment (10 placements per span), keeping only the most inward intersections per sample. Skip smoothing and do not reuse the arc-union fallback.
+- Only expose the innermost line of the oxide preview for open paths—`polygons` stay empty so the renderer no longer shades the ribbon.
+- Canvas rendering removed the gradient ribbon and dashed outer stroke; draw both contours as solid lines to match the single-sided spec.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,9 @@ Think of this file as the living design history.  Out-of-date instructions cause
 
 - `computeCircleEnvelope` now evaluates arc radii directly from the compass polygon per heading instead of clamping to the sample’s own offset. Leave the min-distance enforcement in `deriveInnerGeometry` to guarantee the requested thickness instead of reintroducing local `Math.max` guards.
 - Dense arc sampling pushes every chosen candidate point into the `denseLoop` and bumps the minimum subdivisions to 12 so closed loops keep enough geometry to avoid collapsing when forms are sealed.
+
+## 2025-10-21 — Open-loop dense alignment & regression snapshot
+
+- `deriveInnerGeometry` now resamples open-path `denseLoop` results back to the sampled resolution before aligning with `alignLoop`. After alignment, immediately call `enforceMinimumOffset` so tangential drift still respects the configured oxide floor.
+- A helper `resampleOpenPolyline` lives beside `resampleClosedPolygon`. Reuse it when you need evenly spaced open-line samples.
+- Added `docs/regressions/asymmetric-open-oxidation.svg` as a quick visual check for asymmetric envelopes on open paths. Keep it updated whenever the open-loop offset behaviour changes.

--- a/docs/regressions/README.md
+++ b/docs/regressions/README.md
@@ -1,0 +1,5 @@
+# Regression Snapshots
+
+- **Asymmetric open oxidation** (`asymmetric-open-oxidation.svg`) – demonstrates the enforced minimum thickness after aligning
+dense open-loop samples. The orange trace represents the resampled inner oxide following tangential displacement of the blue
+outer polyline.

--- a/docs/regressions/asymmetric-open-oxidation.svg
+++ b/docs/regressions/asymmetric-open-oxidation.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="320" viewBox="0 0 512 320">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#10121d" />
+      <stop offset="1" stop-color="#05070b" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="320" fill="url(#bg)" />
+  <g fill="none" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <polyline stroke="#52b6ff" points="64 240 176 96 288 152 432 88" />
+    <polyline stroke="#ff9f4d" points="102 212 184 140 270 168 384 136" />
+  </g>
+  <g font-family="'Inter', 'Segoe UI', sans-serif" font-size="20" fill="#d7e3ff">
+    <text x="64" y="276">Outer polyline</text>
+    <text x="272" y="216" fill="#ffd7aa">Aligned asymmetric oxide</text>
+  </g>
+</svg>

--- a/src/canvas/contours.ts
+++ b/src/canvas/contours.ts
@@ -71,21 +71,9 @@ export const drawContours = (
     ctx.globalAlpha = emphasize ? 1 : 0.45;
     ctx.lineWidth = 1.8;
     ctx.strokeStyle = strokeColor;
-    ctx.setLineDash(path.meta.closed ? [] : [6, 3]);
+    ctx.setLineDash([]);
     strokePolyline(ctx, outerScreen, path.meta.closed);
     if (showOxide && outerScreen.length > 1 && innerScreen.length === outerScreen.length) {
-      for (let i = 1; i < outerScreen.length; i += 1) {
-        fillRibbon(ctx, outerScreen[i - 1], outerScreen[i], innerScreen[i], innerScreen[i - 1]);
-      }
-      if (path.meta.closed && outerScreen.length > 2) {
-        fillRibbon(
-          ctx,
-          outerScreen.at(-1)!,
-          outerScreen[0],
-          innerScreen[0],
-          innerScreen.at(-1)!,
-        );
-      }
       ctx.lineWidth = 1;
       ctx.strokeStyle = emphasize ? 'rgba(37, 99, 235, 0.7)' : 'rgba(37, 99, 235, 0.35)';
       strokePolyline(ctx, innerScreen, path.meta.closed);
@@ -118,26 +106,6 @@ export const drawContours = (
     innerWorld.length ? innerWorld : samples.map((sample) => sample.position),
     true,
   );
-};
-
-const fillRibbon = (
-  ctx: CanvasRenderingContext2D,
-  outerA: { x: number; y: number },
-  outerB: { x: number; y: number },
-  innerB: { x: number; y: number },
-  innerA: { x: number; y: number },
-) => {
-  const gradient = ctx.createLinearGradient(outerA.x, outerA.y, innerA.x, innerA.y);
-  gradient.addColorStop(0, 'rgba(37, 99, 235, 0.35)');
-  gradient.addColorStop(1, 'rgba(37, 99, 235, 0.05)');
-  ctx.fillStyle = gradient;
-  ctx.beginPath();
-  ctx.moveTo(outerA.x, outerA.y);
-  ctx.lineTo(outerB.x, outerB.y);
-  ctx.lineTo(innerB.x, innerB.y);
-  ctx.lineTo(innerA.x, innerA.y);
-  ctx.closePath();
-  ctx.fill();
 };
 
 const createMirroredVariants = (


### PR DESCRIPTION
## Summary
- resample dense open-path oxide envelopes back to the sampled resolution before smoothing so alignment respects tangential drift
- add an open-polyline resampling helper and document the workflow update in the agent handbook
- capture an asymmetric open-path regression snapshot for quick visual verification

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dba50c5434832497c17499372e7b60