### PR TITLE
Add canvas pan, panel collapses, and duplication tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,11 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - The canvas no longer renders the oxide ribbon or dashed inner contour; `drawContours` now only strokes the outer path with a solid line. Keep it this way so the preview stays focused on per-point dots.
 - Line oxidation is visualised through `drawOxidationDots`, which drops translated compass patches along each sampled slice. Respect `oxidationDotCount` and the `oxidationVisible` flag when adjusting this overlay.
 - The Oxidation panel exposes a “Line preview dots” slider (0–1000). When touching the store, continue to clamp values via `clampDotCount` so undo/redo snapshots remain consistent.
+
+## 2025-11-04 — Canvas pan, collapsible panels & duplication
+
+- Workspace view state now tracks a `pan` vector alongside `zoom`. Use `panBy`/`setPan` when implementing navigation controls and always pass the active pan into `computeViewTransform` so hit-tests and rendering remain aligned.
+- The right-hand Oxidation and Grid panels expose collapse toggles driven by `panelCollapse`. Update layout logic via `setPanelCollapsed` when adding new side panels and preserve the CSS variable `--right-column` that App.tsx sets for responsive widths.
+- Dragging with the Select tool translates whole paths via `translatePaths`. The helper skips locked paths and records history—reuse it for future bulk transforms instead of reimplementing per-path loops.
+- The Tool panel now offers a Copy action (`duplicateSelectedPaths`, also bound to ⌘/Ctrl+D) that clones the current selection in-place. When introducing new selection tools, make sure they update `selectedPathIds` so duplication remains accurate.
+- Measurement drags are unconstrained ruler reads; probes store real endpoint coordinates instead of snapping to oxidation thickness. Hover measurements still sample the oxidation profile—preserve both modes when refining overlays.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,3 +170,9 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Dragging with the Select tool translates whole paths via `translatePaths`. The helper skips locked paths and records history—reuse it for future bulk transforms instead of reimplementing per-path loops.
 - The Tool panel now offers a Copy action (`duplicateSelectedPaths`, also bound to ⌘/Ctrl+D) that clones the current selection in-place. When introducing new selection tools, make sure they update `selectedPathIds` so duplication remains accurate.
 - Measurement drags are unconstrained ruler reads; probes store real endpoint coordinates instead of snapping to oxidation thickness. Hover measurements still sample the oxidation profile—preserve both modes when refining overlays.
+
+## 2025-11-05 — Centered zoom, roaming grid & collapse toggles
+
+- View transforms now keep the 50 μm workspace centred during zoom and apply pan deltas in canvas space. When adjusting navigation, update `computeViewTransform`/`CanvasViewport` together so drag maths stay stable after zooming.
+- Grid rendering projects from the current canvas bounds via `canvasToWorld`, so it follows the viewport anywhere. Avoid reintroducing fixed `0…extent` loops or the grid will disappear when panning.
+- The right-hand Oxidation/Grid cards collapse into edge buttons (`CollapsedPanelButton`) that free the column width. Any new right-column panels should offer a collapsed affordance so the canvas can reclaim space.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Think of this file as the living design history.  Out-of-date instructions cause
 ## 2025-11-04 — Canvas pan, collapsible panels & duplication
 
 - Workspace view state now tracks a `pan` vector alongside `zoom`. Use `panBy`/`setPan` when implementing navigation controls and always pass the active pan into `computeViewTransform` so hit-tests and rendering remain aligned.
-- The right-hand Oxidation and Grid panels expose collapse toggles driven by `panelCollapse`. Update layout logic via `setPanelCollapsed` when adding new side panels and preserve the CSS variable `--right-column` that App.tsx sets for responsive widths.
+- The right-hand sidebar reclaiming logic hinges on `panelCollapse.rightSidebar`; preserve the CSS variable `--right-column` that App.tsx sets so the canvas can expand when the sidebar is hidden.
 - Dragging with the Select tool translates whole paths via `translatePaths`. The helper skips locked paths and records history—reuse it for future bulk transforms instead of reimplementing per-path loops.
 - The Tool panel now offers a Copy action (`duplicateSelectedPaths`, also bound to ⌘/Ctrl+D) that clones the current selection in-place. When introducing new selection tools, make sure they update `selectedPathIds` so duplication remains accurate.
 - Measurement drags are unconstrained ruler reads; probes store real endpoint coordinates instead of snapping to oxidation thickness. Hover measurements still sample the oxidation profile—preserve both modes when refining overlays.
@@ -175,4 +175,11 @@ Think of this file as the living design history.  Out-of-date instructions cause
 
 - View transforms now keep the 50 μm workspace centred during zoom and apply pan deltas in canvas space. When adjusting navigation, update `computeViewTransform`/`CanvasViewport` together so drag maths stay stable after zooming.
 - Grid rendering projects from the current canvas bounds via `canvasToWorld`, so it follows the viewport anywhere. Avoid reintroducing fixed `0…extent` loops or the grid will disappear when panning.
-- The right-hand Oxidation/Grid cards collapse into edge buttons (`CollapsedPanelButton`) that free the column width. Any new right-column panels should offer a collapsed affordance so the canvas can reclaim space.
+- The right-hand controls now collapse via a shared sidebar toggle. Honour `panelCollapse.rightSidebar` when adjusting layout so `CanvasViewport` width hints stay in sync.
+
+## 2025-11-06 — Unified sidebar collapse & PNG export stub
+
+- `panelCollapse` now only tracks `rightSidebar`; call `setPanelCollapsed(boolean)` to hide or reveal the Oxidation, Grid, and Measurement cards together and update any new UI to respect this global toggle.
+- Legacy snapshots may still carry `panelCollapse.oxidation/grid`; reuse `normalizePanelCollapse` when touching history/import logic so they migrate cleanly.
+- The compass inspector swaps the old helper text for an “Export PNG” button that currently fires an info toast via `pushWarning`. Wire the actual export routine through this button in future changes.
+- App bootstrap now guards the demo circle seeding with a ref so StrictMode’s double effects don’t spawn duplicate geometry. Keep this sentinel in place if you refactor startup flows.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type CSSProperties } from 'react';
 import { CanvasViewport } from './ui/CanvasViewport';
 import { DirectionalCompass } from './ui/DirectionalCompass';
 import { ToolPanel } from './ui/ToolPanel';
@@ -20,6 +20,15 @@ export const App = () => {
   const pathCount = useWorkspaceStore((state) => state.paths.length);
   const bootstrapped = useWorkspaceStore((state) => state.bootstrapped);
   const markBootstrapped = useWorkspaceStore((state) => state.markBootstrapped);
+  const panelCollapse = useWorkspaceStore((state) => state.panelCollapse);
+
+  const rightColumnWidth = panelCollapse.oxidation && panelCollapse.grid
+    ? '200px'
+    : panelCollapse.oxidation || panelCollapse.grid
+      ? '260px'
+      : '320px';
+
+  const gridStyle = { ['--right-column' as const]: rightColumnWidth } as CSSProperties;
 
   useEffect(() => {
     if (!bootstrapped && pathCount === 0) {
@@ -49,7 +58,10 @@ export const App = () => {
             <p className="text-sm text-muted">Oxidation-aware contour planning with live measurement feedback.</p>
           </div>
         </header>
-        <main className="grid grid-cols-1 gap-6 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
+        <main
+          className="grid grid-cols-1 gap-6 xl:[grid-template-columns:280px_minmax(0,1fr)_var(--right-column,320px)]"
+          style={gridStyle}
+        >
           <div className="flex flex-col gap-4">
             <DirectionalCompass />
             <ToolPanel />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,21 @@ import { useWorkspaceStore } from './state';
 import { createId } from './utils/ids';
 import { createCircleNodes } from './utils/presets';
 
+interface CollapsedPanelButtonProps {
+  label: string;
+  onClick: () => void;
+}
+
+const CollapsedPanelButton = ({ label, onClick }: CollapsedPanelButtonProps) => (
+  <button
+    type="button"
+    className="self-end rounded-full border border-border bg-surface px-4 py-2 text-xs font-semibold uppercase tracking-wide text-accent shadow transition hover:bg-surface/90"
+    onClick={onClick}
+  >
+    Expand {label}
+  </button>
+);
+
 export const App = () => {
   useKeyboardShortcuts();
   const addPath = useWorkspaceStore((state) => state.addPath);
@@ -21,11 +36,12 @@ export const App = () => {
   const bootstrapped = useWorkspaceStore((state) => state.bootstrapped);
   const markBootstrapped = useWorkspaceStore((state) => state.markBootstrapped);
   const panelCollapse = useWorkspaceStore((state) => state.panelCollapse);
+  const setPanelCollapsed = useWorkspaceStore((state) => state.setPanelCollapsed);
 
   const rightColumnWidth = panelCollapse.oxidation && panelCollapse.grid
-    ? '200px'
+    ? 'max-content'
     : panelCollapse.oxidation || panelCollapse.grid
-      ? '260px'
+      ? '240px'
       : '320px';
 
   const gridStyle = { ['--right-column' as const]: rightColumnWidth } as CSSProperties;
@@ -69,9 +85,23 @@ export const App = () => {
             <ImportExportPanel />
           </div>
           <CanvasViewport />
-          <div className="flex flex-col gap-4">
-            <OxidationPanel />
-            <GridMirrorPanel />
+          <div className="flex flex-col items-stretch gap-4">
+            {panelCollapse.oxidation ? (
+              <CollapsedPanelButton
+                label="Oxidation"
+                onClick={() => setPanelCollapsed('oxidation', false)}
+              />
+            ) : (
+              <OxidationPanel />
+            )}
+            {panelCollapse.grid ? (
+              <CollapsedPanelButton
+                label="Grid"
+                onClick={() => setPanelCollapsed('grid', false)}
+              />
+            ) : (
+              <GridMirrorPanel />
+            )}
             <MeasurementPanel />
           </div>
         </main>

--- a/src/canvas/contours.ts
+++ b/src/canvas/contours.ts
@@ -1,4 +1,4 @@
-import type { MirrorSettings, PathEntity, SamplePoint, Vec2 } from '../types';
+import type { DirectionWeight, MirrorSettings, PathEntity, SamplePoint, Vec2 } from '../types';
 import { evalThicknessForAngle } from '../geometry';
 import { distance } from '../utils/math';
 import { worldToCanvas, type ViewTransform } from './viewTransform';
@@ -98,7 +98,7 @@ const LENGTH_EPS = 1e-6;
 
 const computeDotPolygon = (options: {
   uniformThickness: number;
-  weights: Array<{ angleDeg: number; valueUm: number }>;
+  weights: DirectionWeight[];
   mirrorSymmetry: boolean;
   progress: number;
 }): Vec2[] => {

--- a/src/canvas/grid.ts
+++ b/src/canvas/grid.ts
@@ -1,5 +1,5 @@
 import type { GridSettings } from '../types';
-import { VIEW_EXTENT_UM, worldToCanvas, type ViewTransform } from './viewTransform';
+import { canvasToWorld, worldToCanvas, type ViewTransform } from './viewTransform';
 
 export const drawGrid = (
   ctx: CanvasRenderingContext2D,
@@ -9,39 +9,53 @@ export const drawGrid = (
   if (!settings.visible) return;
   const spacing = Math.max(4, settings.spacing);
   const subdivisions = Math.max(1, settings.subdivisions);
+  const subSpacing = spacing / subdivisions;
+  const topLeft = canvasToWorld({ x: 0, y: 0 }, view);
+  const bottomRight = canvasToWorld({ x: view.canvasWidth, y: view.canvasHeight }, view);
+  const minX = Math.min(topLeft.x, bottomRight.x);
+  const maxX = Math.max(topLeft.x, bottomRight.x);
+  const minY = Math.min(topLeft.y, bottomRight.y);
+  const maxY = Math.max(topLeft.y, bottomRight.y);
+  const startMajorX = Math.floor(minX / spacing) * spacing;
+  const endMajorX = Math.ceil(maxX / spacing) * spacing;
+  const startMajorY = Math.floor(minY / spacing) * spacing;
+  const endMajorY = Math.ceil(maxY / spacing) * spacing;
+  const startMinorX = Math.floor(minX / subSpacing) * subSpacing;
+  const endMinorX = Math.ceil(maxX / subSpacing) * subSpacing;
+  const startMinorY = Math.floor(minY / subSpacing) * subSpacing;
+  const endMinorY = Math.ceil(maxY / subSpacing) * subSpacing;
+
   ctx.save();
   ctx.lineWidth = 1;
   ctx.strokeStyle = 'rgba(148, 163, 184, 0.25)';
-  const extent = VIEW_EXTENT_UM;
-  const subSpacing = spacing / subdivisions;
-  for (let x = 0; x <= extent; x += spacing) {
-    const a = worldToCanvas({ x, y: 0 }, view);
-    const b = worldToCanvas({ x, y: extent }, view);
+  for (let x = startMajorX; x <= endMajorX; x += spacing) {
+    const a = worldToCanvas({ x, y: minY }, view);
+    const b = worldToCanvas({ x, y: maxY }, view);
     ctx.beginPath();
     ctx.moveTo(a.x, a.y);
     ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
-  for (let y = 0; y <= extent; y += spacing) {
-    const a = worldToCanvas({ x: 0, y }, view);
-    const b = worldToCanvas({ x: extent, y }, view);
+  for (let y = startMajorY; y <= endMajorY; y += spacing) {
+    const a = worldToCanvas({ x: minX, y }, view);
+    const b = worldToCanvas({ x: maxX, y }, view);
     ctx.beginPath();
     ctx.moveTo(a.x, a.y);
     ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
   ctx.strokeStyle = 'rgba(148, 163, 184, 0.15)';
-  for (let x = 0; x <= extent; x += subSpacing) {
-    const a = worldToCanvas({ x, y: 0 }, view);
-    const b = worldToCanvas({ x, y: extent }, view);
+  for (let x = startMinorX; x <= endMinorX; x += subSpacing) {
+    const a = worldToCanvas({ x, y: minY }, view);
+    const b = worldToCanvas({ x, y: maxY }, view);
     ctx.beginPath();
     ctx.moveTo(a.x, a.y);
     ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
-  for (let y = 0; y <= extent; y += subSpacing) {
-    const a = worldToCanvas({ x: 0, y }, view);
-    const b = worldToCanvas({ x: extent, y }, view);
+  for (let y = startMinorY; y <= endMinorY; y += subSpacing) {
+    const a = worldToCanvas({ x: minX, y }, view);
+    const b = worldToCanvas({ x: maxX, y }, view);
     ctx.beginPath();
     ctx.moveTo(a.x, a.y);
     ctx.lineTo(b.x, b.y);

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -72,7 +72,7 @@ export class CanvasRenderer {
     this.ctx.clearRect(0, 0, width, height);
     const logicalWidth = width / this.dpr;
     const logicalHeight = height / this.dpr;
-    const view = computeViewTransform(logicalWidth, logicalHeight, state.zoom);
+    const view = computeViewTransform(logicalWidth, logicalHeight, state.zoom, state.pan);
     drawGrid(this.ctx, state.grid, view);
     drawMirrorAxes(this.ctx, state.mirror, view);
     const showHeatmap = state.measurements.showHeatmap;

--- a/src/canvas/viewTransform.ts
+++ b/src/canvas/viewTransform.ts
@@ -6,6 +6,8 @@ export interface ViewTransform {
   offsetY: number;
   extent: number;
   zoom: number;
+  originX: number;
+  originY: number;
 }
 
 export const VIEW_EXTENT_UM = 50;
@@ -14,25 +16,36 @@ export const computeViewTransform = (
   width: number,
   height: number,
   zoom = 1,
+  pan: Vec2 = { x: 0, y: 0 },
 ): ViewTransform => {
   const extent = VIEW_EXTENT_UM;
   const span = Math.max(Math.min(width, height), 1);
   const clampedZoom = Math.max(0.1, Math.min(zoom, 10));
   const scale = (span / extent) * clampedZoom || 1;
   const viewportExtent = extent / clampedZoom;
-  const offsetX = (width - viewportExtent * scale) / 2;
-  const offsetY = (height - viewportExtent * scale) / 2;
-  return { scale: scale || 1, offsetX, offsetY, extent: viewportExtent, zoom: clampedZoom };
+  const originX = pan.x;
+  const originY = pan.y;
+  const offsetX = (width - viewportExtent * scale) / 2 - originX * scale;
+  const offsetY = (height - viewportExtent * scale) / 2 - originY * scale;
+  return {
+    scale: scale || 1,
+    offsetX,
+    offsetY,
+    extent: viewportExtent,
+    zoom: clampedZoom,
+    originX,
+    originY,
+  };
 };
 
 export const worldToCanvas = (point: Vec2, view: ViewTransform): Vec2 => ({
-  x: view.offsetX + point.x * view.scale,
-  y: view.offsetY + point.y * view.scale,
+  x: view.offsetX + (point.x - view.originX) * view.scale,
+  y: view.offsetY + (point.y - view.originY) * view.scale,
 });
 
 export const canvasToWorld = (point: Vec2, view: ViewTransform): Vec2 => ({
-  x: (point.x - view.offsetX) / view.scale,
-  y: (point.y - view.offsetY) / view.scale,
+  x: (point.x - view.offsetX) / view.scale + view.originX,
+  y: (point.y - view.offsetY) / view.scale + view.originY,
 });
 
 export const worldDistanceToCanvas = (distance: number, view: ViewTransform): number =>

--- a/src/canvas/viewTransform.ts
+++ b/src/canvas/viewTransform.ts
@@ -6,8 +6,10 @@ export interface ViewTransform {
   offsetY: number;
   extent: number;
   zoom: number;
-  originX: number;
-  originY: number;
+  centerX: number;
+  centerY: number;
+  canvasWidth: number;
+  canvasHeight: number;
 }
 
 export const VIEW_EXTENT_UM = 50;
@@ -23,29 +25,32 @@ export const computeViewTransform = (
   const clampedZoom = Math.max(0.1, Math.min(zoom, 10));
   const scale = (span / extent) * clampedZoom || 1;
   const viewportExtent = extent / clampedZoom;
-  const originX = pan.x;
-  const originY = pan.y;
-  const offsetX = (width - viewportExtent * scale) / 2 - originX * scale;
-  const offsetY = (height - viewportExtent * scale) / 2 - originY * scale;
+  const baseCenter = extent / 2;
+  const centerX = baseCenter + pan.x;
+  const centerY = baseCenter + pan.y;
+  const offsetX = width / 2 - centerX * scale;
+  const offsetY = height / 2 - centerY * scale;
   return {
     scale: scale || 1,
     offsetX,
     offsetY,
     extent: viewportExtent,
     zoom: clampedZoom,
-    originX,
-    originY,
+    centerX,
+    centerY,
+    canvasWidth: width,
+    canvasHeight: height,
   };
 };
 
 export const worldToCanvas = (point: Vec2, view: ViewTransform): Vec2 => ({
-  x: view.offsetX + (point.x - view.originX) * view.scale,
-  y: view.offsetY + (point.y - view.originY) * view.scale,
+  x: view.offsetX + point.x * view.scale,
+  y: view.offsetY + point.y * view.scale,
 });
 
 export const canvasToWorld = (point: Vec2, view: ViewTransform): Vec2 => ({
-  x: (point.x - view.offsetX) / view.scale + view.originX,
-  y: (point.y - view.offsetY) / view.scale + view.originY,
+  x: (point.x - view.offsetX) / view.scale,
+  y: (point.y - view.offsetY) / view.scale,
 });
 
 export const worldDistanceToCanvas = (distance: number, view: ViewTransform): number =>

--- a/src/state/workspaceStore.ts
+++ b/src/state/workspaceStore.ts
@@ -756,6 +756,7 @@ const createEmptyState = (library: StoredShape[] = []): WorkspaceState => ({
   selectedPathIds: [],
   nodeSelection: null,
   activeTool: 'line',
+  pan: { x: 0, y: 0 },
   zoom: 1,
   grid: {
     visible: true,
@@ -787,6 +788,10 @@ const createEmptyState = (library: StoredShape[] = []): WorkspaceState => ({
   directionalLinking: true,
   bootstrapped: false,
   library,
+  panelCollapse: {
+    oxidation: false,
+    grid: false,
+  },
 });
 
 const clonePath = (path: PathEntity): PathEntity => ({
@@ -819,17 +824,22 @@ const captureSnapshot = (state: WorkspaceState): WorkspaceSnapshot => ({
   oxidationProgress: state.oxidationProgress,
   oxidationDotCount: state.oxidationDotCount,
   zoom: state.zoom,
+  pan: { ...state.pan },
+  panelCollapse: { ...state.panelCollapse },
 });
 
 type PathUpdater = (nodes: PathNode[]) => PathNode[];
 
 type WorkspaceActions = {
   setActiveTool: (tool: ToolId) => void;
+  setPan: (pan: Vec2) => void;
+  panBy: (delta: Vec2) => void;
   addPath: (nodes: PathNode[], overrides?: Partial<PathEntity>) => string;
   updatePath: (id: string, updater: PathUpdater) => void;
   removePath: (id: string) => void;
   setSelected: (ids: string[]) => void;
   setNodeSelection: (selection: NodeSelection | null) => void;
+  translatePaths: (pathIds: string[], delta: Vec2) => void;
   deleteSelectedNodes: () => void;
   setNodeCurveMode: (pathId: string, nodeId: string, mode: 'line' | 'bezier') => void;
   updateGrid: (settings: Partial<WorkspaceState['grid']>) => void;
@@ -840,6 +850,7 @@ type WorkspaceActions = {
   setOxidationProgress: (value: number) => void;
   setZoom: (zoom: number) => void;
   zoomBy: (delta: number) => void;
+  duplicateSelectedPaths: () => void;
   setPathMeta: (id: string, patch: Partial<PathMeta>) => void;
   setHoverProbe: (probe: MeasurementProbe | null) => void;
   setPinnedProbe: (probe: MeasurementProbe | null) => void;
@@ -851,6 +862,7 @@ type WorkspaceActions = {
   toggleOxidationVisible: (value: boolean) => void;
   setOxidationDotCount: (value: number) => void;
   markBootstrapped: () => void;
+  setPanelCollapsed: (panel: keyof WorkspaceState['panelCollapse'], collapsed: boolean) => void;
   saveShapeToLibrary: (pathId: string, name: string) => void;
   removeShapeFromLibrary: (shapeId: string) => void;
   renameShapeInLibrary: (shapeId: string, name: string) => void;
@@ -942,6 +954,12 @@ const initialLibrary = loadLibrary();
 export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   ...createEmptyState(initialLibrary),
   setActiveTool: (tool) => set({ activeTool: tool }),
+  setPan: (pan) => set((state) => ({ ...state, pan })),
+  panBy: (delta) =>
+    set((state) => ({
+      ...state,
+      pan: { x: state.pan.x + delta.x, y: state.pan.y + delta.y },
+    })),
   setZoom: (zoom) => set((state) => ({ ...state, zoom: clampZoom(zoom) })),
   zoomBy: (delta) =>
     set((state) => ({
@@ -1060,6 +1078,102 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         ? { pathId: selection.pathId, nodeIds: [...selection.nodeIds] }
         : null,
     })),
+  translatePaths: (pathIds, delta) =>
+    set((state) => {
+      if (!pathIds.length) return state;
+      if (Math.abs(delta.x) < 1e-6 && Math.abs(delta.y) < 1e-6) return state;
+      const ids = new Set(pathIds);
+      let moved = false;
+      const history = [...state.history, captureSnapshot(state)].slice(-50);
+      const shiftHandle = (handle: Vec2 | null | undefined): Vec2 | null | undefined => {
+        if (handle === null || handle === undefined) return handle;
+        return { x: handle.x + delta.x, y: handle.y + delta.y };
+      };
+      const nextPaths = state.paths.map((path) => {
+        if (!ids.has(path.meta.id) || path.meta.locked) {
+          return path;
+        }
+        moved = true;
+        const movedNodes = path.nodes.map((node) => ({
+          ...node,
+          point: { x: node.point.x + delta.x, y: node.point.y + delta.y },
+          handleIn: shiftHandle(node.handleIn),
+          handleOut: shiftHandle(node.handleOut),
+        }));
+        return runGeometryPipeline(
+          {
+            ...path,
+            nodes: movedNodes,
+            meta: { ...path.meta, updatedAt: Date.now() },
+          },
+          state.oxidationProgress,
+        );
+      });
+      if (!moved) {
+        return state;
+      }
+      return {
+        ...state,
+        paths: nextPaths,
+        history,
+        future: [],
+        dirty: true,
+      };
+    }),
+  duplicateSelectedPaths: () =>
+    set((state) => {
+      if (!state.selectedPathIds.length) return state;
+      const history = [...state.history, captureSnapshot(state)].slice(-50);
+      const selected = new Set(state.selectedPathIds);
+      const now = Date.now();
+      const newPaths: PathEntity[] = [];
+      const newSelection: string[] = [];
+      state.paths.forEach((path) => {
+        if (!selected.has(path.meta.id)) return;
+        const newId = createId('path');
+        const cloneHandle = (handle: Vec2 | null | undefined): Vec2 | null | undefined => {
+          if (handle === null || handle === undefined) return handle;
+          return { ...handle };
+        };
+        const clonedNodes = path.nodes.map((node) => ({
+          ...node,
+          id: createId('node'),
+          point: { ...node.point },
+          handleIn: cloneHandle(node.handleIn),
+          handleOut: cloneHandle(node.handleOut),
+        }));
+        const meta: PathMeta = {
+          ...path.meta,
+          id: newId,
+          name: `${path.meta.name} copy`,
+          createdAt: now,
+          updatedAt: now,
+        };
+        const duplicated = runGeometryPipeline(
+          {
+            meta,
+            nodes: clonedNodes,
+            oxidation: cloneOxidationSettings(path.oxidation),
+            sampled: undefined,
+          },
+          state.oxidationProgress,
+        );
+        newPaths.push(duplicated);
+        newSelection.push(newId);
+      });
+      if (!newPaths.length) {
+        return state;
+      }
+      return {
+        ...state,
+        paths: [...state.paths, ...newPaths],
+        selectedPathIds: newSelection,
+        nodeSelection: null,
+        history,
+        future: [],
+        dirty: true,
+      };
+    }),
   deleteSelectedNodes: () =>
     set((state) => {
       const selection = state.nodeSelection;
@@ -1254,6 +1368,10 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   toggleOxidationVisible: (value) => set({ oxidationVisible: value }),
   setOxidationDotCount: (value) => set({ oxidationDotCount: clampDotCount(value) }),
   markBootstrapped: () => set({ bootstrapped: true }),
+  setPanelCollapsed: (panel, collapsed) =>
+    set((state) => ({
+      panelCollapse: { ...state.panelCollapse, [panel]: collapsed },
+    })),
   saveShapeToLibrary: (pathId, name) =>
     set((state) => {
       const path = state.paths.find((entry) => entry.meta.id === pathId);
@@ -1321,6 +1439,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       dirty: true,
       bootstrapped: true,
       oxidationDotCount: DEFAULT_DOT_COUNT,
+      pan: { x: 0, y: 0 },
+      panelCollapse: { oxidation: false, grid: false },
     })),
   undo: () => {
     const { history } = get();
@@ -1343,6 +1463,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         oxidationProgress: previous.oxidationProgress,
         oxidationDotCount: previous.oxidationDotCount,
         zoom: previous.zoom,
+        pan: { ...previous.pan },
+        panelCollapse: { ...previous.panelCollapse },
       };
     });
   },
@@ -1367,6 +1489,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         oxidationProgress: snapshot.oxidationProgress,
         oxidationDotCount: snapshot.oxidationDotCount,
         zoom: snapshot.zoom,
+        pan: { ...snapshot.pan },
+        panelCollapse: { ...snapshot.panelCollapse },
       };
     });
   },
@@ -1384,6 +1508,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       future: [],
       dirty: false,
       zoom: clampZoom(payload.zoom ?? 1),
+      pan: payload.pan ?? { x: 0, y: 0 },
+      panelCollapse: payload.panelCollapse ?? { oxidation: false, grid: false },
     })),
   reset: () =>
     set((state) => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,8 +108,7 @@ export interface MeasurementState {
 }
 
 export interface PanelCollapseState {
-  oxidation: boolean;
-  grid: boolean;
+  rightSidebar: boolean;
 }
 
 export interface NodeSelection {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,4 @@
-export type ToolId =
-  | 'select'
-  | 'line'
-  | 'dot'
-  | 'measure'
-  | 'oxidize'
-  | 'pan'
-  | 'erase';
+export type ToolId = 'select' | 'line' | 'dot' | 'measure' | 'pan' | 'erase';
 
 export interface Vec2 {
   x: number;
@@ -114,6 +107,11 @@ export interface MeasurementState {
   showHeatmap: boolean;
 }
 
+export interface PanelCollapseState {
+  oxidation: boolean;
+  grid: boolean;
+}
+
 export interface NodeSelection {
   pathId: string;
   nodeIds: string[];
@@ -142,6 +140,8 @@ export interface WorkspaceSnapshot {
   oxidationProgress: number;
   oxidationDotCount: number;
   zoom: number;
+  pan: Vec2;
+  panelCollapse: PanelCollapseState;
 }
 
 export interface WorkspaceState {
@@ -149,6 +149,7 @@ export interface WorkspaceState {
   selectedPathIds: string[];
   nodeSelection: NodeSelection | null;
   activeTool: ToolId;
+  pan: Vec2;
   grid: GridSettings;
   mirror: MirrorSettings;
   oxidationDefaults: OxidationSettings;
@@ -164,6 +165,7 @@ export interface WorkspaceState {
   bootstrapped: boolean;
   library: StoredShape[];
   zoom: number;
+  panelCollapse: PanelCollapseState;
 }
 
 export interface ExportedProject {

--- a/src/ui/CanvasViewport.tsx
+++ b/src/ui/CanvasViewport.tsx
@@ -61,7 +61,7 @@ export const CanvasViewport = () => {
   const zoomBy = useWorkspaceStore((state) => state.zoomBy);
   const pan = useWorkspaceStore((state) => state.pan);
   const panBy = useWorkspaceStore((state) => state.panBy);
-  const panelCollapse = useWorkspaceStore((state) => state.panelCollapse);
+  const rightSidebarCollapsed = useWorkspaceStore((state) => state.panelCollapse.rightSidebar);
   const measureStart = useRef<{ origin: Vec2; moved: boolean } | null>(null);
   const dragTarget = useRef<DragTarget | null>(null);
   const selectionDrag = useRef<{ pathIds: string[]; last: Vec2; moved: boolean } | null>(null);
@@ -69,11 +69,7 @@ export const CanvasViewport = () => {
   const penDraft = useRef<{ pathId: string; activeEnd: 'start' | 'end' } | null>(null);
   const [cursorHint, setCursorHint] = useState<string | null>(null);
 
-  const canvasWidthClass = panelCollapse.oxidation && panelCollapse.grid
-    ? 'max-w-[1080px]'
-    : panelCollapse.oxidation || panelCollapse.grid
-      ? 'max-w-[920px]'
-      : 'max-w-[760px]';
+  const canvasWidthClass = rightSidebarCollapsed ? 'max-w-[1080px]' : 'max-w-[760px]';
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/src/ui/CanvasViewport.tsx
+++ b/src/ui/CanvasViewport.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type PointerEvent, type WheelEvent } from 'react';
+import { clsx } from 'clsx';
 import { createRenderer } from '../canvas/renderer';
 import { useWorkspaceStore } from '../state';
 import { createId } from '../utils/ids';
@@ -48,6 +49,7 @@ export const CanvasViewport = () => {
   const measurements = useWorkspaceStore((state) => state.measurements);
   const setSelected = useWorkspaceStore((state) => state.setSelected);
   const setNodeSelection = useWorkspaceStore((state) => state.setNodeSelection);
+  const translatePaths = useWorkspaceStore((state) => state.translatePaths);
   const updatePath = useWorkspaceStore((state) => state.updatePath);
   const addPath = useWorkspaceStore((state) => state.addPath);
   const setPathMeta = useWorkspaceStore((state) => state.setPathMeta);
@@ -57,10 +59,21 @@ export const CanvasViewport = () => {
   const zoom = useWorkspaceStore((state) => state.zoom);
   const setZoom = useWorkspaceStore((state) => state.setZoom);
   const zoomBy = useWorkspaceStore((state) => state.zoomBy);
+  const pan = useWorkspaceStore((state) => state.pan);
+  const panBy = useWorkspaceStore((state) => state.panBy);
+  const panelCollapse = useWorkspaceStore((state) => state.panelCollapse);
   const measureStart = useRef<{ origin: Vec2; moved: boolean } | null>(null);
   const dragTarget = useRef<DragTarget | null>(null);
+  const selectionDrag = useRef<{ pathIds: string[]; last: Vec2; moved: boolean } | null>(null);
+  const panSession = useRef<{ last: Vec2 } | null>(null);
   const penDraft = useRef<{ pathId: string; activeEnd: 'start' | 'end' } | null>(null);
   const [cursorHint, setCursorHint] = useState<string | null>(null);
+
+  const canvasWidthClass = panelCollapse.oxidation && panelCollapse.grid
+    ? 'max-w-[900px]'
+    : panelCollapse.oxidation || panelCollapse.grid
+      ? 'max-w-[800px]'
+      : 'max-w-[720px]';
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -77,7 +90,7 @@ export const CanvasViewport = () => {
   } => {
     const canvas = canvasRef.current;
     if (!canvas) {
-      const view = computeViewTransform(1, 1, zoom);
+      const view = computeViewTransform(1, 1, zoom, pan);
       return { world: { x: 0, y: 0 }, canvas: { x: 0, y: 0 }, view };
     }
     const rect = canvas.getBoundingClientRect();
@@ -85,7 +98,7 @@ export const CanvasViewport = () => {
       x: event.clientX - rect.left,
       y: event.clientY - rect.top,
     };
-    const view = computeViewTransform(rect.width, rect.height, zoom);
+    const view = computeViewTransform(rect.width, rect.height, zoom, pan);
     const world = canvasToWorld(canvasPoint, view);
     return { world, canvas: canvasPoint, view };
   };
@@ -380,9 +393,14 @@ export const CanvasViewport = () => {
         b: position,
         distance: 0,
         angleDeg: 0,
-        thicknessA: 0,
-        thicknessB: 0,
+        thicknessA: undefined,
+        thicknessB: undefined,
       });
+      canvasRef.current?.setPointerCapture(event.pointerId);
+      return;
+    }
+    if (activeTool === 'pan') {
+      panSession.current = { last: position };
       canvasRef.current?.setPointerCapture(event.pointerId);
       return;
     }
@@ -432,8 +450,19 @@ export const CanvasViewport = () => {
       }
       const pathId = hitTestPath(position, view);
       if (pathId) {
-        setSelected([pathId]);
+        const state = useWorkspaceStore.getState();
+        const path = state.paths.find((entry) => entry.meta.id === pathId);
+        const nextSelection = state.selectedPathIds.includes(pathId)
+          ? [...state.selectedPathIds]
+          : [pathId];
+        setSelected(nextSelection);
         setNodeSelection(null);
+        if (path && !path.meta.locked) {
+          selectionDrag.current = { pathIds: nextSelection, last: position, moved: false };
+          canvasRef.current?.setPointerCapture(event.pointerId);
+          return;
+        }
+        return;
       } else if (!event.shiftKey) {
         setSelected([]);
         setNodeSelection(null);
@@ -455,31 +484,49 @@ export const CanvasViewport = () => {
           measureStart.current.moved = true;
         }
         const angle = Math.atan2(dy, dx);
-        const thickness = sampleGlobalThickness(angle);
-        const dirLength = Math.hypot(dx, dy);
-        const basis =
-          dirLength > 1e-6
-            ? { x: dx / dirLength, y: dy / dirLength }
-            : { x: Math.cos(angle), y: Math.sin(angle) };
-        const endpoint = {
-          x: origin.x + basis.x * thickness,
-          y: origin.y + basis.y * thickness,
-        };
         setDragProbe({
           ...measurements.dragProbe,
-          b: endpoint,
-          distance: thickness,
+          b: position,
+          distance: rawDistance,
           angleDeg: toDegrees(angle),
-          thicknessA: thickness,
-          thicknessB: thickness,
+          thicknessA: undefined,
+          thicknessB: undefined,
         });
       } else {
         updateHoverMeasurement(position, view);
       }
       return;
     }
-    if (activeTool === 'select' && dragTarget.current) {
-      updateGeometryForDrag(dragTarget.current, position);
+    if (activeTool === 'pan') {
+      if (panSession.current) {
+        const last = panSession.current.last;
+        const delta = { x: position.x - last.x, y: position.y - last.y };
+        if (Math.abs(delta.x) > 1e-6 || Math.abs(delta.y) > 1e-6) {
+          panBy({ x: -delta.x, y: -delta.y });
+          panSession.current.last = position;
+        }
+      }
+      return;
+    }
+    if (activeTool === 'select') {
+      if (dragTarget.current) {
+        updateGeometryForDrag(dragTarget.current, position);
+        return;
+      }
+      if (selectionDrag.current) {
+        const session = selectionDrag.current;
+        const delta = { x: position.x - session.last.x, y: position.y - session.last.y };
+        if (Math.abs(delta.x) > 1e-6 || Math.abs(delta.y) > 1e-6) {
+          translatePaths(session.pathIds, delta);
+          const deltaLength = Math.hypot(delta.x, delta.y);
+          const moveThreshold = canvasDistanceToWorld(0.75, view);
+          if (!session.moved && deltaLength > moveThreshold) {
+            session.moved = true;
+          }
+          session.last = position;
+        }
+        return;
+      }
     }
   };
 
@@ -507,6 +554,8 @@ export const CanvasViewport = () => {
       canvasRef.current?.releasePointerCapture(event.pointerId);
       return;
     }
+    selectionDrag.current = null;
+    panSession.current = null;
     dragTarget.current = null;
     canvasRef.current?.releasePointerCapture(event.pointerId);
   };
@@ -535,8 +584,23 @@ export const CanvasViewport = () => {
     }
   }, [activeTool, setDragProbe, setHoverProbe]);
 
+  useEffect(() => {
+    if (activeTool !== 'select') {
+      selectionDrag.current = null;
+      dragTarget.current = null;
+    }
+    if (activeTool !== 'pan') {
+      panSession.current = null;
+    }
+  }, [activeTool]);
+
   return (
-    <div className="relative aspect-square w-full max-h-[80vh] max-w-[720px] self-start overflow-hidden rounded-3xl border border-border bg-surface shadow-panel">
+    <div
+      className={clsx(
+        'relative aspect-square w-full max-h-[80vh] self-start overflow-hidden rounded-3xl border border-border bg-surface shadow-panel',
+        canvasWidthClass,
+      )}
+    >
       <canvas
         ref={canvasRef}
         className="h-full w-full touch-none"

--- a/src/ui/DirectionalCompass.tsx
+++ b/src/ui/DirectionalCompass.tsx
@@ -515,10 +515,6 @@ export const DirectionalCompass = () => {
             <div className="pointer-events-none absolute inset-0 rounded-full border-2 border-dashed border-accent/40" />
           )}
         </div>
-        <div className="text-center text-[11px] text-muted">
-          Click a spoke to adjust its μm offset below. Enable the chain to move every heading together. Toggle the plus icon
-          and click the outer rim to add a new heading.
-        </div>
       </div>
       <div className="rounded-2xl border border-border/70 bg-white/80 p-4">
         {selectedWeight ? (

--- a/src/ui/DirectionalCompass.tsx
+++ b/src/ui/DirectionalCompass.tsx
@@ -93,6 +93,7 @@ export const DirectionalCompass = () => {
   const updateDefaults = useWorkspaceStore((state) => state.updateOxidationDefaults);
   const linking = useWorkspaceStore((state) => state.directionalLinking);
   const setLinking = useWorkspaceStore((state) => state.setDirectionalLinking);
+  const pushWarning = useWorkspaceStore((state) => state.pushWarning);
   const oxidationProgress = useWorkspaceStore((state) => state.oxidationProgress);
 
   const activeWeights = defaults.thicknessByDirection.items;
@@ -575,8 +576,14 @@ export const DirectionalCompass = () => {
             </div>
           </div>
         ) : (
-          <div className="text-center text-[11px] text-muted">
-            Select a spoke to edit its label, heading angle, and μm contribution. Use the plus rim to add more headings.
+          <div className="flex justify-center">
+            <button
+              type="button"
+              className="rounded-full border border-border bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-accent shadow-sm transition hover:bg-white"
+              onClick={() => pushWarning('PNG export is coming soon.', 'info')}
+            >
+              Export PNG
+            </button>
           </div>
         )}
       </div>

--- a/src/ui/GridMirrorPanel.tsx
+++ b/src/ui/GridMirrorPanel.tsx
@@ -5,75 +5,90 @@ export const GridMirrorPanel = () => {
   const mirror = useWorkspaceStore((state) => state.mirror);
   const updateGrid = useWorkspaceStore((state) => state.updateGrid);
   const updateMirror = useWorkspaceStore((state) => state.updateMirror);
+  const collapsed = useWorkspaceStore((state) => state.panelCollapse.grid);
+  const setPanelCollapsed = useWorkspaceStore((state) => state.setPanelCollapsed);
 
   return (
-    <div className="panel flex flex-col gap-4 p-4">
-      <div className="section-title">Grid</div>
-      <div className="flex flex-col gap-3 text-xs text-muted">
-        <ToggleRow
-          label="Visible"
-          checked={grid.visible}
-          onChange={(value) => updateGrid({ visible: value })}
-        />
-        <ToggleRow
-          label="Snap to grid"
-          checked={grid.snapToGrid}
-          onChange={(value) => updateGrid({ snapToGrid: value })}
-        />
-        <NumberField
-          label="Spacing"
-          value={grid.spacing}
-          min={4}
-          max={256}
-          onChange={(value) => updateGrid({ spacing: value })}
-        />
-        <NumberField
-          label="Subdivisions"
-          value={grid.subdivisions}
-          min={1}
-          max={16}
-          onChange={(value) => updateGrid({ subdivisions: value })}
-        />
+    <div className="panel flex flex-col gap-3 p-4">
+      <div className="flex items-center justify-between">
+        <div className="section-title">Grid</div>
+        <button
+          type="button"
+          className="text-[11px] font-semibold text-accent transition hover:text-accent/80"
+          onClick={() => setPanelCollapsed('grid', !collapsed)}
+        >
+          {collapsed ? 'Expand' : 'Collapse'}
+        </button>
       </div>
-      <div className="section-title">Mirror</div>
-      <div className="flex flex-col gap-3 text-xs text-muted">
-        <ToggleRow
-          label="Enabled"
-          checked={mirror.enabled}
-          onChange={(value) => updateMirror({ enabled: value })}
-        />
-        <label className="input-label flex items-center justify-between">
-          Axis
-          <select
-            value={mirror.axis}
-            onChange={(event) => updateMirror({ axis: event.target.value as typeof mirror.axis })}
-            className="input-field ml-3 w-28"
-          >
-            <option value="x">X</option>
-            <option value="y">Y</option>
-            <option value="xy">Both</option>
-          </select>
-        </label>
-        <NumberField
-          label="Origin X"
-          value={mirror.origin.x}
-          min={-4096}
-          max={4096}
-          onChange={(value) => updateMirror({ origin: { ...mirror.origin, x: value } })}
-        />
-        <NumberField
-          label="Origin Y"
-          value={mirror.origin.y}
-          min={-4096}
-          max={4096}
-          onChange={(value) => updateMirror({ origin: { ...mirror.origin, y: value } })}
-        />
-        <ToggleRow
-          label="Live preview"
-          checked={mirror.livePreview}
-          onChange={(value) => updateMirror({ livePreview: value })}
-        />
-      </div>
+      {!collapsed && (
+        <>
+          <div className="flex flex-col gap-3 text-xs text-muted">
+            <ToggleRow
+              label="Visible"
+              checked={grid.visible}
+              onChange={(value) => updateGrid({ visible: value })}
+            />
+            <ToggleRow
+              label="Snap to grid"
+              checked={grid.snapToGrid}
+              onChange={(value) => updateGrid({ snapToGrid: value })}
+            />
+            <NumberField
+              label="Spacing"
+              value={grid.spacing}
+              min={4}
+              max={256}
+              onChange={(value) => updateGrid({ spacing: value })}
+            />
+            <NumberField
+              label="Subdivisions"
+              value={grid.subdivisions}
+              min={1}
+              max={16}
+              onChange={(value) => updateGrid({ subdivisions: value })}
+            />
+          </div>
+          <div className="section-title">Mirror</div>
+          <div className="flex flex-col gap-3 text-xs text-muted">
+            <ToggleRow
+              label="Enabled"
+              checked={mirror.enabled}
+              onChange={(value) => updateMirror({ enabled: value })}
+            />
+            <label className="input-label flex items-center justify-between">
+              Axis
+              <select
+                value={mirror.axis}
+                onChange={(event) => updateMirror({ axis: event.target.value as typeof mirror.axis })}
+                className="input-field ml-3 w-28"
+              >
+                <option value="x">X</option>
+                <option value="y">Y</option>
+                <option value="xy">Both</option>
+              </select>
+            </label>
+            <NumberField
+              label="Origin X"
+              value={mirror.origin.x}
+              min={-4096}
+              max={4096}
+              onChange={(value) => updateMirror({ origin: { ...mirror.origin, x: value } })}
+            />
+            <NumberField
+              label="Origin Y"
+              value={mirror.origin.y}
+              min={-4096}
+              max={4096}
+              onChange={(value) => updateMirror({ origin: { ...mirror.origin, y: value } })}
+            />
+            <ToggleRow
+              label="Live preview"
+              checked={mirror.livePreview}
+              onChange={(value) => updateMirror({ livePreview: value })}
+            />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/ui/GridMirrorPanel.tsx
+++ b/src/ui/GridMirrorPanel.tsx
@@ -5,90 +5,75 @@ export const GridMirrorPanel = () => {
   const mirror = useWorkspaceStore((state) => state.mirror);
   const updateGrid = useWorkspaceStore((state) => state.updateGrid);
   const updateMirror = useWorkspaceStore((state) => state.updateMirror);
-  const collapsed = useWorkspaceStore((state) => state.panelCollapse.grid);
-  const setPanelCollapsed = useWorkspaceStore((state) => state.setPanelCollapsed);
 
   return (
     <div className="panel flex flex-col gap-3 p-4">
-      <div className="flex items-center justify-between">
-        <div className="section-title">Grid</div>
-        <button
-          type="button"
-          className="text-[11px] font-semibold text-accent transition hover:text-accent/80"
-          onClick={() => setPanelCollapsed('grid', !collapsed)}
-        >
-          {collapsed ? 'Expand' : 'Collapse'}
-        </button>
+      <div className="section-title">Grid</div>
+      <div className="flex flex-col gap-3 text-xs text-muted">
+        <ToggleRow
+          label="Visible"
+          checked={grid.visible}
+          onChange={(value) => updateGrid({ visible: value })}
+        />
+        <ToggleRow
+          label="Snap to grid"
+          checked={grid.snapToGrid}
+          onChange={(value) => updateGrid({ snapToGrid: value })}
+        />
+        <NumberField
+          label="Spacing"
+          value={grid.spacing}
+          min={4}
+          max={256}
+          onChange={(value) => updateGrid({ spacing: value })}
+        />
+        <NumberField
+          label="Subdivisions"
+          value={grid.subdivisions}
+          min={1}
+          max={16}
+          onChange={(value) => updateGrid({ subdivisions: value })}
+        />
       </div>
-      {!collapsed && (
-        <>
-          <div className="flex flex-col gap-3 text-xs text-muted">
-            <ToggleRow
-              label="Visible"
-              checked={grid.visible}
-              onChange={(value) => updateGrid({ visible: value })}
-            />
-            <ToggleRow
-              label="Snap to grid"
-              checked={grid.snapToGrid}
-              onChange={(value) => updateGrid({ snapToGrid: value })}
-            />
-            <NumberField
-              label="Spacing"
-              value={grid.spacing}
-              min={4}
-              max={256}
-              onChange={(value) => updateGrid({ spacing: value })}
-            />
-            <NumberField
-              label="Subdivisions"
-              value={grid.subdivisions}
-              min={1}
-              max={16}
-              onChange={(value) => updateGrid({ subdivisions: value })}
-            />
-          </div>
-          <div className="section-title">Mirror</div>
-          <div className="flex flex-col gap-3 text-xs text-muted">
-            <ToggleRow
-              label="Enabled"
-              checked={mirror.enabled}
-              onChange={(value) => updateMirror({ enabled: value })}
-            />
-            <label className="input-label flex items-center justify-between">
-              Axis
-              <select
-                value={mirror.axis}
-                onChange={(event) => updateMirror({ axis: event.target.value as typeof mirror.axis })}
-                className="input-field ml-3 w-28"
-              >
-                <option value="x">X</option>
-                <option value="y">Y</option>
-                <option value="xy">Both</option>
-              </select>
-            </label>
-            <NumberField
-              label="Origin X"
-              value={mirror.origin.x}
-              min={-4096}
-              max={4096}
-              onChange={(value) => updateMirror({ origin: { ...mirror.origin, x: value } })}
-            />
-            <NumberField
-              label="Origin Y"
-              value={mirror.origin.y}
-              min={-4096}
-              max={4096}
-              onChange={(value) => updateMirror({ origin: { ...mirror.origin, y: value } })}
-            />
-            <ToggleRow
-              label="Live preview"
-              checked={mirror.livePreview}
-              onChange={(value) => updateMirror({ livePreview: value })}
-            />
-          </div>
-        </>
-      )}
+      <div className="section-title">Mirror</div>
+      <div className="flex flex-col gap-3 text-xs text-muted">
+        <ToggleRow
+          label="Enabled"
+          checked={mirror.enabled}
+          onChange={(value) => updateMirror({ enabled: value })}
+        />
+        <label className="input-label flex items-center justify-between">
+          Axis
+          <select
+            value={mirror.axis}
+            onChange={(event) => updateMirror({ axis: event.target.value as typeof mirror.axis })}
+            className="input-field ml-3 w-28"
+          >
+            <option value="x">X</option>
+            <option value="y">Y</option>
+            <option value="xy">Both</option>
+          </select>
+        </label>
+        <NumberField
+          label="Origin X"
+          value={mirror.origin.x}
+          min={-4096}
+          max={4096}
+          onChange={(value) => updateMirror({ origin: { ...mirror.origin, x: value } })}
+        />
+        <NumberField
+          label="Origin Y"
+          value={mirror.origin.y}
+          min={-4096}
+          max={4096}
+          onChange={(value) => updateMirror({ origin: { ...mirror.origin, y: value } })}
+        />
+        <ToggleRow
+          label="Live preview"
+          checked={mirror.livePreview}
+          onChange={(value) => updateMirror({ livePreview: value })}
+        />
+      </div>
     </div>
   );
 };

--- a/src/ui/OxidationPanel.tsx
+++ b/src/ui/OxidationPanel.tsx
@@ -10,6 +10,8 @@ export const OxidationPanel = () => {
   const toggleVisible = useWorkspaceStore((state) => state.toggleOxidationVisible);
   const dotCount = useWorkspaceStore((state) => state.oxidationDotCount);
   const setDotCount = useWorkspaceStore((state) => state.setOxidationDotCount);
+  const collapsed = useWorkspaceStore((state) => state.panelCollapse.oxidation);
+  const setPanelCollapsed = useWorkspaceStore((state) => state.setPanelCollapsed);
   const active = defaults;
 
   const directionValues = useMemo(
@@ -33,64 +35,73 @@ export const OxidationPanel = () => {
   );
 
   return (
-    <div className="panel flex flex-col gap-4 p-4">
-      <div className="section-title">Oxidation</div>
-      <label className="flex items-center justify-between text-xs font-medium text-muted">
-        <span>Show compass dots</span>
-        <input
-          type="checkbox"
-          className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
-          checked={oxidationVisible}
-          onChange={(event) => toggleVisible(event.target.checked)}
-        />
-      </label>
-      <div className="grid grid-cols-3 gap-3 text-xs text-muted">
-        {preview.map((item) => (
-          <div key={item.label} className="rounded-xl bg-accentSoft/60 px-3 py-2 text-center text-[11px]">
-            <div className="font-semibold text-text">{item.value}</div>
-            <div>{item.label}</div>
+    <div className="panel flex flex-col gap-3 p-4">
+      <div className="flex items-center justify-between">
+        <div className="section-title">Oxidation</div>
+        <button
+          type="button"
+          className="text-[11px] font-semibold text-accent transition hover:text-accent/80"
+          onClick={() => setPanelCollapsed('oxidation', !collapsed)}
+        >
+          {collapsed ? 'Expand' : 'Collapse'}
+        </button>
+      </div>
+      {!collapsed && (
+        <>
+          <label className="flex items-center justify-between text-xs font-medium text-muted">
+            <span>Show compass dots</span>
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
+              checked={oxidationVisible}
+              onChange={(event) => toggleVisible(event.target.checked)}
+            />
+          </label>
+          <div className="grid grid-cols-3 gap-3 text-xs text-muted">
+            {preview.map((item) => (
+              <div key={item.label} className="rounded-xl bg-accentSoft/60 px-3 py-2 text-center text-[11px]">
+                <div className="font-semibold text-text">{item.value}</div>
+                <div>{item.label}</div>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-      <div className="flex flex-col gap-3 text-sm">
-        <LabeledSlider
-          label="Uniform thickness"
-          min={0}
-          max={10}
-          step={0.1}
-          value={active.thicknessUniformUm}
-          onChange={(value) => {
-            const clamped = Math.min(10, Math.max(0, value));
-            updateDefaults({ thicknessUniformUm: clamped });
-          }}
-        />
-        <LabeledSlider
-          label="Line preview dots"
-          min={0}
-          max={1000}
-          step={1}
-          value={dotCount}
-          onChange={(value) => {
-            setDotCount(value);
-          }}
-          format={(value) => Math.round(value).toString()}
-        />
-      </div>
-      <div className="rounded-2xl border border-dashed border-border/70 bg-white/60 p-3 text-xs text-muted">
-        Use the compass card on the left to add, remove, or edit directional μm offsets. Toggle the chain icon there to choose
-        whether neighbouring headings adapt automatically.
-      </div>
-      <label className="flex items-center gap-2 text-xs font-medium text-muted">
-        <input
-          type="checkbox"
-          className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
-          checked={active.mirrorSymmetry}
-          onChange={(event) => {
-            updateDefaults({ mirrorSymmetry: event.target.checked });
-          }}
-        />
-        Mirror symmetry
-      </label>
+          <div className="flex flex-col gap-3 text-sm">
+            <LabeledSlider
+              label="Uniform thickness"
+              min={0}
+              max={10}
+              step={0.1}
+              value={active.thicknessUniformUm}
+              onChange={(value) => {
+                const clamped = Math.min(10, Math.max(0, value));
+                updateDefaults({ thicknessUniformUm: clamped });
+              }}
+            />
+            <LabeledSlider
+              label="Line preview dots"
+              min={0}
+              max={1000}
+              step={1}
+              value={dotCount}
+              onChange={(value) => {
+                setDotCount(value);
+              }}
+              format={(value) => Math.round(value).toString()}
+            />
+          </div>
+          <label className="flex items-center gap-2 text-xs font-medium text-muted">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
+              checked={active.mirrorSymmetry}
+              onChange={(event) => {
+                updateDefaults({ mirrorSymmetry: event.target.checked });
+              }}
+            />
+            Mirror symmetry
+          </label>
+        </>
+      )}
     </div>
   );
 };

--- a/src/ui/OxidationPanel.tsx
+++ b/src/ui/OxidationPanel.tsx
@@ -10,8 +10,6 @@ export const OxidationPanel = () => {
   const toggleVisible = useWorkspaceStore((state) => state.toggleOxidationVisible);
   const dotCount = useWorkspaceStore((state) => state.oxidationDotCount);
   const setDotCount = useWorkspaceStore((state) => state.setOxidationDotCount);
-  const collapsed = useWorkspaceStore((state) => state.panelCollapse.oxidation);
-  const setPanelCollapsed = useWorkspaceStore((state) => state.setPanelCollapsed);
   const active = defaults;
 
   const directionValues = useMemo(
@@ -36,72 +34,59 @@ export const OxidationPanel = () => {
 
   return (
     <div className="panel flex flex-col gap-3 p-4">
-      <div className="flex items-center justify-between">
-        <div className="section-title">Oxidation</div>
-        <button
-          type="button"
-          className="text-[11px] font-semibold text-accent transition hover:text-accent/80"
-          onClick={() => setPanelCollapsed('oxidation', !collapsed)}
-        >
-          {collapsed ? 'Expand' : 'Collapse'}
-        </button>
+      <div className="section-title">Oxidation</div>
+      <label className="flex items-center justify-between text-xs font-medium text-muted">
+        <span>Show compass dots</span>
+        <input
+          type="checkbox"
+          className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
+          checked={oxidationVisible}
+          onChange={(event) => toggleVisible(event.target.checked)}
+        />
+      </label>
+      <div className="grid grid-cols-3 gap-3 text-xs text-muted">
+        {preview.map((item) => (
+          <div key={item.label} className="rounded-xl bg-accentSoft/60 px-3 py-2 text-center text-[11px]">
+            <div className="font-semibold text-text">{item.value}</div>
+            <div>{item.label}</div>
+          </div>
+        ))}
       </div>
-      {!collapsed && (
-        <>
-          <label className="flex items-center justify-between text-xs font-medium text-muted">
-            <span>Show compass dots</span>
-            <input
-              type="checkbox"
-              className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
-              checked={oxidationVisible}
-              onChange={(event) => toggleVisible(event.target.checked)}
-            />
-          </label>
-          <div className="grid grid-cols-3 gap-3 text-xs text-muted">
-            {preview.map((item) => (
-              <div key={item.label} className="rounded-xl bg-accentSoft/60 px-3 py-2 text-center text-[11px]">
-                <div className="font-semibold text-text">{item.value}</div>
-                <div>{item.label}</div>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-col gap-3 text-sm">
-            <LabeledSlider
-              label="Uniform thickness"
-              min={0}
-              max={10}
-              step={0.1}
-              value={active.thicknessUniformUm}
-              onChange={(value) => {
-                const clamped = Math.min(10, Math.max(0, value));
-                updateDefaults({ thicknessUniformUm: clamped });
-              }}
-            />
-            <LabeledSlider
-              label="Line preview dots"
-              min={0}
-              max={1000}
-              step={1}
-              value={dotCount}
-              onChange={(value) => {
-                setDotCount(value);
-              }}
-              format={(value) => Math.round(value).toString()}
-            />
-          </div>
-          <label className="flex items-center gap-2 text-xs font-medium text-muted">
-            <input
-              type="checkbox"
-              className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
-              checked={active.mirrorSymmetry}
-              onChange={(event) => {
-                updateDefaults({ mirrorSymmetry: event.target.checked });
-              }}
-            />
-            Mirror symmetry
-          </label>
-        </>
-      )}
+      <div className="flex flex-col gap-3 text-sm">
+        <LabeledSlider
+          label="Uniform thickness"
+          min={0}
+          max={10}
+          step={0.1}
+          value={active.thicknessUniformUm}
+          onChange={(value) => {
+            const clamped = Math.min(10, Math.max(0, value));
+            updateDefaults({ thicknessUniformUm: clamped });
+          }}
+        />
+        <LabeledSlider
+          label="Line preview dots"
+          min={0}
+          max={1000}
+          step={1}
+          value={dotCount}
+          onChange={(value) => {
+            setDotCount(value);
+          }}
+          format={(value) => Math.round(value).toString()}
+        />
+      </div>
+      <label className="flex items-center gap-2 text-xs font-medium text-muted">
+        <input
+          type="checkbox"
+          className="h-4 w-4 rounded border-border text-accent focus:ring-accent"
+          checked={active.mirrorSymmetry}
+          onChange={(event) => {
+            updateDefaults({ mirrorSymmetry: event.target.checked });
+          }}
+        />
+        Mirror symmetry
+      </label>
     </div>
   );
 };

--- a/src/ui/ToolPanel.tsx
+++ b/src/ui/ToolPanel.tsx
@@ -6,7 +6,6 @@ const tools: Array<{ id: ToolId; label: string; shortcut: string }> = [
   { id: 'select', label: 'Select', shortcut: 'V' },
   { id: 'line', label: 'Line', shortcut: 'L' },
   { id: 'dot', label: 'Dot', shortcut: 'D' },
-  { id: 'oxidize', label: 'Oxidize', shortcut: 'O' },
   { id: 'measure', label: 'Measure', shortcut: 'M' },
   { id: 'pan', label: 'Pan', shortcut: 'Space' },
 ];
@@ -14,6 +13,8 @@ const tools: Array<{ id: ToolId; label: string; shortcut: string }> = [
 export const ToolPanel = () => {
   const activeTool = useWorkspaceStore((state) => state.activeTool);
   const setActiveTool = useWorkspaceStore((state) => state.setActiveTool);
+  const duplicateSelectedPaths = useWorkspaceStore((state) => state.duplicateSelectedPaths);
+  const hasSelection = useWorkspaceStore((state) => state.selectedPathIds.length > 0);
 
   return (
     <div className="panel flex flex-col gap-3 p-4">
@@ -31,6 +32,15 @@ export const ToolPanel = () => {
           </button>
         ))}
       </div>
+      <button
+        type="button"
+        className="toolbar-button"
+        onClick={() => duplicateSelectedPaths()}
+        disabled={!hasSelection}
+      >
+        <span>Copy selection</span>
+        <span className="text-[10px] text-muted">⌘D</span>
+      </button>
     </div>
   );
 };

--- a/src/ui/useKeyboardShortcuts.ts
+++ b/src/ui/useKeyboardShortcuts.ts
@@ -6,7 +6,6 @@ const keyMap: Record<string, ToolId> = {
   v: 'select',
   l: 'line',
   d: 'dot',
-  o: 'oxidize',
   m: 'measure',
 };
 
@@ -15,6 +14,7 @@ export const useKeyboardShortcuts = () => {
   const undo = useWorkspaceStore((state) => state.undo);
   const redo = useWorkspaceStore((state) => state.redo);
   const deleteSelectedNodes = useWorkspaceStore((state) => state.deleteSelectedNodes);
+  const duplicateSelectedPaths = useWorkspaceStore((state) => state.duplicateSelectedPaths);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -29,6 +29,11 @@ export const useKeyboardShortcuts = () => {
         } else {
           undo();
         }
+        return;
+      }
+      if ((event.metaKey || event.ctrlKey) && key === 'd') {
+        event.preventDefault();
+        duplicateSelectedPaths();
         return;
       }
       if (key in keyMap) {
@@ -46,5 +51,5 @@ export const useKeyboardShortcuts = () => {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [deleteSelectedNodes, redo, setActiveTool, undo]);
+  }, [deleteSelectedNodes, duplicateSelectedPaths, redo, setActiveTool, undo]);
 };


### PR DESCRIPTION
## Summary
- add workspace pan state, extend the view transform, and wire the canvas renderer/viewport to support panning with the new tool
- let the select tool drag whole paths, expose a copy action (with ⌘/Ctrl+D), and make measurement drags act as free rulers
- collapse the oxidation and grid panels to free canvas width and adjust the layout accordingly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e38b7a2a5c8324a435d6b8637c9941