### PR TITLE
Add DXF import/export and reference path mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,3 +194,9 @@ Think of this file as the living design history.  Out-of-date instructions cause
 ## 2025-11-08 — Tool selector memoisation guard
 
 - Components should never subscribe to Zustand selectors that build new arrays or objects on every render; doing so trips React’s external-store guard and bricks the UI with an infinite update loop. Derive filtered selections with `useMemo` (fed by stable store slices) or provide a comparator when you need structural equality.
+
+## 2025-11-09 — Path kind inspector & DXF arc sampling
+
+- The path type selector now lives on the right rail beneath the Oxidation card. Keep its mixed-selection banner and reuse `setPathType` so undo/redo and the geometry pipeline stay consistent when flipping modes.
+- DXF import now approximates `ARC` and `CIRCLE` entities into polylines (64 segments for a full circle). Preserve this conversion so guides from AutoCAD round-trip without manual edits, and keep centring the result in the 50 μm workspace before adding paths.
+- The canvas centre column no longer hard-limits its width when the sidebar is expanded, ensuring the gap matches the left rail, and zoom tops out at ×4. Honour these bounds when adjusting layout or viewport behaviour.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,3 +183,10 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Legacy snapshots may still carry `panelCollapse.oxidation/grid`; reuse `normalizePanelCollapse` when touching history/import logic so they migrate cleanly.
 - The compass inspector swaps the old helper text for an “Export PNG” button that currently fires an info toast via `pushWarning`. Wire the actual export routine through this button in future changes.
 - App bootstrap now guards the demo circle seeding with a ref so StrictMode’s double effects don’t spawn duplicate geometry. Keep this sentinel in place if you refactor startup flows.
+
+## 2025-11-07 — DXF interchange & reference geometry mode
+
+- Paths now carry a `meta.kind` (`'oxided'` | `'reference'`). Reference paths act as grey, non-oxidised guides: no dots, no thickness evaluation, and no per-node editing. Use `setPathType` to flip modes so undo/redo and geometry recomputation stay in sync.
+- Canvas hit-tests skip reference paths for node/segment edits and handles never render for them. They can still be translated as a whole via `translatePaths`.
+- `runGeometryPipeline` zeros thickness/inner geometry for reference paths. If you create new entry points, make sure reference mode routes through this same guard before invoking the offset solver.
+- DXF import/export lives under `src/utils/dxf.ts`. The importer supports `LINE` and `LWPOLYLINE` entities, recentres everything to the 50 μm workspace, and maps the `REFERENCE` layer to the reference path kind. Keep exports using those same layers so round-trips remain lossless.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,3 +190,7 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Canvas hit-tests skip reference paths for node/segment edits and handles never render for them. They can still be translated as a whole via `translatePaths`.
 - `runGeometryPipeline` zeros thickness/inner geometry for reference paths. If you create new entry points, make sure reference mode routes through this same guard before invoking the offset solver.
 - DXF import/export lives under `src/utils/dxf.ts`. The importer supports `LINE` and `LWPOLYLINE` entities, recentres everything to the 50 μm workspace, and maps the `REFERENCE` layer to the reference path kind. Keep exports using those same layers so round-trips remain lossless.
+
+## 2025-11-08 — Tool selector memoisation guard
+
+- Components should never subscribe to Zustand selectors that build new arrays or objects on every render; doing so trips React’s external-store guard and bricks the UI with an infinite update loop. Derive filtered selections with `useMemo` (fed by stable store slices) or provide a comparator when you need structural equality.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,13 @@ import { useEffect, useRef, type CSSProperties } from 'react';
 import { CanvasViewport } from './ui/CanvasViewport';
 import { DirectionalCompass } from './ui/DirectionalCompass';
 import { ToolPanel } from './ui/ToolPanel';
-import { ScenePanel } from './ui/ScenePanel';
 import { OxidationPanel } from './ui/OxidationPanel';
 import { GridMirrorPanel } from './ui/GridMirrorPanel';
 import { MeasurementPanel } from './ui/MeasurementPanel';
 import { StatusBar } from './ui/StatusBar';
 import { ImportExportPanel } from './ui/ImportExportPanel';
+import { ScenePanel } from './ui/ScenePanel';
+import { PathTypePanel } from './ui/PathTypePanel';
 import { useKeyboardShortcuts } from './ui/useKeyboardShortcuts';
 import { useWorkspaceStore } from './state';
 import { createId } from './utils/ids';
@@ -85,8 +86,8 @@ export const App = () => {
           <div className="flex flex-col gap-4">
             <DirectionalCompass />
             <ToolPanel />
-            <ScenePanel />
             <ImportExportPanel />
+            <ScenePanel />
           </div>
           <CanvasViewport />
           <div className="flex flex-col items-stretch gap-4">
@@ -97,6 +98,7 @@ export const App = () => {
             {!rightCollapsed && (
               <>
                 <OxidationPanel />
+                <PathTypePanel />
                 <GridMirrorPanel />
                 <MeasurementPanel />
               </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ export const App = () => {
             visible: true,
             locked: false,
             color: '#2563eb',
+            kind: 'oxided',
             createdAt: Date.now(),
             updatedAt: Date.now(),
           },

--- a/src/canvas/contours.ts
+++ b/src/canvas/contours.ts
@@ -66,15 +66,20 @@ export const drawContours = (
     return;
   }
 
-  const strokeColor = selected ? '#2563eb' : path.meta.color;
+  const isReference = path.meta.kind === 'reference';
+  const strokeColor = selected
+    ? '#2563eb'
+    : isReference
+      ? '#94a3b8'
+      : path.meta.color;
 
   const drawVariant = (points: Vec2[], emphasize: boolean) => {
     if (!points.length) return;
     const screenPoints = points.map((point) => worldToCanvas(point, view));
     if (!screenPoints.length) return;
     ctx.save();
-    ctx.globalAlpha = emphasize ? 1 : 0.45;
-    ctx.lineWidth = 1.8;
+    ctx.globalAlpha = emphasize ? 1 : isReference ? 0.35 : 0.45;
+    ctx.lineWidth = isReference ? 1.5 : 1.8;
     ctx.strokeStyle = strokeColor;
     ctx.setLineDash([]);
     strokePolyline(ctx, screenPoints, path.meta.closed);
@@ -208,7 +213,7 @@ export const drawOxidationDots = (
   mirror: MirrorSettings | undefined,
   visible: boolean,
 ): void => {
-  if (!visible) return;
+  if (!visible || path.meta.kind === 'reference') return;
   const samples = path.sampled?.samples;
   if (!samples?.length) return;
 

--- a/src/canvas/handles.ts
+++ b/src/canvas/handles.ts
@@ -8,7 +8,7 @@ export const drawHandles = (
   view: ViewTransform,
   nodeSelection: NodeSelection | null,
 ): void => {
-  if (!selected) return;
+  if (!selected || path.meta.kind === 'reference') return;
   ctx.save();
   ctx.strokeStyle = 'rgba(37, 99, 235, 0.35)';
   ctx.fillStyle = '#2563eb';

--- a/src/canvas/heatmap.ts
+++ b/src/canvas/heatmap.ts
@@ -12,6 +12,7 @@ export const drawHeatmap = (
   path: PathEntity,
   view: ViewTransform,
 ): void => {
+  if (path.meta.kind === 'reference') return;
   const samples = path.sampled?.samples;
   if (!samples?.length) return;
   const values = samples.map((sample) => sample.thickness);

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -82,20 +82,22 @@ export class CanvasRenderer {
 
     state.paths.forEach((path) => {
       const selected = state.selectedPathIds.includes(path.meta.id);
-      if (showHeatmap) {
+      if (showHeatmap && path.meta.kind !== 'reference') {
         drawHeatmap(this.ctx, path, view);
       }
       drawContours(this.ctx, path, selected, view, state.mirror);
-      drawOxidationDots(
-        this.ctx,
-        path,
-        selected,
-        dotCount,
-        progress,
-        view,
-        state.mirror,
-        showDots,
-      );
+      if (path.meta.kind !== 'reference') {
+        drawOxidationDots(
+          this.ctx,
+          path,
+          selected,
+          dotCount,
+          progress,
+          view,
+          state.mirror,
+          showDots,
+        );
+      }
       drawHandles(this.ctx, path, selected, view, state.nodeSelection);
     });
     drawSnaps(this.ctx, state.paths, state.measurements, view);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export type ToolId = 'select' | 'line' | 'dot' | 'measure' | 'pan' | 'erase';
 
+export type PathKind = 'oxided' | 'reference';
+
 export interface Vec2 {
   x: number;
   y: number;
@@ -32,6 +34,7 @@ export interface PathMeta {
   visible: boolean;
   locked: boolean;
   color: string;
+  kind: PathKind;
   createdAt: number;
   updatedAt: number;
 }
@@ -71,6 +74,7 @@ export interface StoredShape {
   name: string;
   nodes: PathNode[];
   oxidation: OxidationSettings;
+  pathType: PathKind;
   createdAt: number;
   updatedAt: number;
 }

--- a/src/ui/CanvasViewport.tsx
+++ b/src/ui/CanvasViewport.tsx
@@ -20,7 +20,7 @@ type DragTarget =
 const nodeHitThresholdPx = 12;
 const pathHitThresholdPx = 10;
 const MIN_ZOOM = 0.25;
-const MAX_ZOOM = 8;
+const MAX_ZOOM = 4;
 const ZOOM_STEP = 1.1;
 
 const pointSegmentDistance = (p: Vec2, a: Vec2, b: Vec2): number => {
@@ -69,7 +69,7 @@ export const CanvasViewport = () => {
   const penDraft = useRef<{ pathId: string; activeEnd: 'start' | 'end' } | null>(null);
   const [cursorHint, setCursorHint] = useState<string | null>(null);
 
-  const canvasWidthClass = rightSidebarCollapsed ? 'max-w-[1080px]' : 'max-w-[760px]';
+  const canvasWidthClass = rightSidebarCollapsed ? 'max-w-[1080px]' : 'max-w-none';
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/src/ui/ImportExportPanel.tsx
+++ b/src/ui/ImportExportPanel.tsx
@@ -1,13 +1,24 @@
 import { useRef, type ChangeEvent } from 'react';
-import { exportProjectToJSON, importProjectFromJSON, exportProjectToPNG, exportProjectToSVG } from '../utils/io';
+import {
+  exportProjectToJSON,
+  importProjectFromJSON,
+  exportProjectToPNG,
+  exportProjectToSVG,
+} from '../utils/io';
+import { parseDXFShapes, serializePathsToDXF } from '../utils/dxf';
 import { useWorkspaceStore } from '../state';
+import { createId } from '../utils/ids';
 
 export const ImportExportPanel = () => {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const dxfInputRef = useRef<HTMLInputElement | null>(null);
   const undo = useWorkspaceStore((state) => state.undo);
   const redo = useWorkspaceStore((state) => state.redo);
   const importState = useWorkspaceStore((state) => state.importState);
   const pushWarning = useWorkspaceStore((state) => state.pushWarning);
+  const addPath = useWorkspaceStore((state) => state.addPath);
+  const setSelected = useWorkspaceStore((state) => state.setSelected);
+  const setNodeSelection = useWorkspaceStore((state) => state.setNodeSelection);
   const getState = useWorkspaceStore.getState;
 
   const handleExportJSON = () => {
@@ -31,6 +42,7 @@ export const ImportExportPanel = () => {
       console.error(error);
       pushWarning('Failed to import JSON', 'error');
     }
+    event.target.value = '';
   };
 
   const handleExportPNG = async () => {
@@ -51,6 +63,66 @@ export const ImportExportPanel = () => {
     URL.revokeObjectURL(link.href);
   };
 
+  const handleExportDXF = () => {
+    const { paths } = getState();
+    if (!paths.length) {
+      pushWarning('Nothing to export', 'warning');
+      return;
+    }
+    const dxf = serializePathsToDXF(paths);
+    const blob = new Blob([dxf], { type: 'application/dxf' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'visoxid-scene.dxf';
+    link.click();
+    URL.revokeObjectURL(link.href);
+  };
+
+  const handleImportDXF = async (event: ChangeEvent<HTMLInputElement>) => {
+    const [file] = event.target.files ?? [];
+    if (!file) return;
+    const text = await file.text();
+    try {
+      const shapes = parseDXFShapes(text);
+      if (!shapes.length) {
+        pushWarning('DXF contained no supported entities', 'warning');
+        return;
+      }
+      const ids: string[] = [];
+      shapes.forEach((shape, index) => {
+        const nodes = shape.points.map((point) => ({
+          id: createId('node'),
+          point: { ...point },
+          handleIn: null,
+          handleOut: null,
+        }));
+        const metaId = createId('path');
+        const pathId = addPath(nodes, {
+          meta: {
+            id: metaId,
+            name: `${shape.kind === 'reference' ? 'Reference' : 'Imported'} ${index + 1}`,
+            closed: shape.closed,
+            visible: true,
+            locked: false,
+            color: '#2563eb',
+            kind: shape.kind,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        });
+        ids.push(pathId);
+      });
+      if (ids.length) {
+        setSelected(ids);
+        setNodeSelection(null);
+      }
+    } catch (error) {
+      console.error(error);
+      pushWarning('Failed to import DXF', 'error');
+    }
+    event.target.value = '';
+  };
+
   return (
     <div className="panel flex flex-col gap-3 p-4 text-xs text-muted">
       <div className="section-title">Project</div>
@@ -67,8 +139,15 @@ export const ImportExportPanel = () => {
         <button type="button" className="toolbar-button" onClick={handleExportSVG}>
           SVG stub
         </button>
+        <button type="button" className="toolbar-button" onClick={handleExportDXF}>
+          Export DXF
+        </button>
+        <button type="button" className="toolbar-button" onClick={() => dxfInputRef.current?.click()}>
+          Import DXF
+        </button>
       </div>
       <input ref={inputRef} type="file" accept="application/json" className="hidden" onChange={handleImportJSON} />
+      <input ref={dxfInputRef} type="file" accept=".dxf" className="hidden" onChange={handleImportDXF} />
       <div className="mt-2 flex items-center justify-between">
         <button type="button" className="toolbar-button" onClick={undo}>
           Undo

--- a/src/ui/PathTypePanel.tsx
+++ b/src/ui/PathTypePanel.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { clsx } from 'clsx';
+import { useWorkspaceStore } from '../state';
+import type { PathKind } from '../types';
+
+const pathTypes: Array<{ id: PathKind; label: string; description: string }> = [
+  { id: 'oxided', label: 'Oxided', description: 'Shows oxidation' },
+  { id: 'reference', label: 'Reference', description: 'Reference outline' },
+];
+
+export const PathTypePanel = () => {
+  const paths = useWorkspaceStore((state) => state.paths);
+  const selectedPathIds = useWorkspaceStore((state) => state.selectedPathIds);
+  const setPathType = useWorkspaceStore((state) => state.setPathType);
+
+  const selectedPaths = useMemo(
+    () => paths.filter((path) => selectedPathIds.includes(path.meta.id)),
+    [paths, selectedPathIds],
+  );
+
+  const selectionState: PathKind | 'mixed' | null = (() => {
+    if (!selectedPaths.length) return null;
+    const first = selectedPaths[0].meta.kind;
+    return selectedPaths.every((path) => path.meta.kind === first) ? first : 'mixed';
+  })();
+
+  return (
+    <div className="panel flex flex-col gap-3 p-4">
+      <div className="section-title">Path type</div>
+      {selectionState === 'mixed' && (
+        <div className="rounded-xl border border-dashed border-border px-3 py-2 text-[11px] text-muted">
+          Mixed selection
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-2">
+        {pathTypes.map((type) => (
+          <button
+            key={type.id}
+            type="button"
+            className={clsx(
+              'toolbar-button h-full text-left',
+              selectionState === type.id && 'toolbar-button-active',
+            )}
+            onClick={() => setPathType(type.id)}
+            disabled={!selectedPaths.length}
+          >
+            <span className="font-semibold">{type.label}</span>
+            <span className="text-[10px] text-muted">{type.description}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PathTypePanel;

--- a/src/ui/ScenePanel.tsx
+++ b/src/ui/ScenePanel.tsx
@@ -105,6 +105,7 @@ export const ScenePanel = () => {
                 visible: true,
                 locked: false,
                 color: '#2563eb',
+                kind: 'reference',
                 createdAt: Date.now(),
                 updatedAt: Date.now(),
               },
@@ -114,7 +115,7 @@ export const ScenePanel = () => {
           Add reference circle
         </button>
       </div>
-      {selectedPath && activeNode && (
+      {selectedPath && activeNode && selectedPath.meta.kind !== 'reference' && (
         <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-border/70 bg-white/70 p-3 text-xs text-muted">
           <div className="text-[11px] uppercase tracking-wide text-muted">Selected node</div>
           <div className="flex justify-between text-[11px] font-semibold text-text">

--- a/src/ui/ToolPanel.tsx
+++ b/src/ui/ToolPanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { clsx } from 'clsx';
 import { useWorkspaceStore } from '../state';
 import type { PathKind, ToolId } from '../types';
@@ -19,11 +20,16 @@ export const ToolPanel = () => {
   const activeTool = useWorkspaceStore((state) => state.activeTool);
   const setActiveTool = useWorkspaceStore((state) => state.setActiveTool);
   const duplicateSelectedPaths = useWorkspaceStore((state) => state.duplicateSelectedPaths);
-  const hasSelection = useWorkspaceStore((state) => state.selectedPathIds.length > 0);
-  const selectedPaths = useWorkspaceStore((state) =>
-    state.paths.filter((path) => state.selectedPathIds.includes(path.meta.id)),
-  );
+  const selectedPathIds = useWorkspaceStore((state) => state.selectedPathIds);
+  const paths = useWorkspaceStore((state) => state.paths);
   const setPathType = useWorkspaceStore((state) => state.setPathType);
+
+  const hasSelection = selectedPathIds.length > 0;
+
+  const selectedPaths = useMemo(
+    () => paths.filter((path) => selectedPathIds.includes(path.meta.id)),
+    [paths, selectedPathIds],
+  );
 
   const selectionState: PathKind | 'mixed' | null = (() => {
     if (!selectedPaths.length) return null;

--- a/src/ui/ToolPanel.tsx
+++ b/src/ui/ToolPanel.tsx
@@ -1,7 +1,6 @@
-import { useMemo } from 'react';
 import { clsx } from 'clsx';
 import { useWorkspaceStore } from '../state';
-import type { PathKind, ToolId } from '../types';
+import type { ToolId } from '../types';
 
 const tools: Array<{ id: ToolId; label: string; shortcut: string }> = [
   { id: 'select', label: 'Select', shortcut: 'V' },
@@ -11,31 +10,13 @@ const tools: Array<{ id: ToolId; label: string; shortcut: string }> = [
   { id: 'pan', label: 'Pan', shortcut: 'Space' },
 ];
 
-const pathTypes: Array<{ id: PathKind; label: string; description: string }> = [
-  { id: 'oxided', label: 'Oxided', description: 'Shows oxidation' },
-  { id: 'reference', label: 'Reference', description: 'Reference outline' },
-];
-
 export const ToolPanel = () => {
   const activeTool = useWorkspaceStore((state) => state.activeTool);
   const setActiveTool = useWorkspaceStore((state) => state.setActiveTool);
   const duplicateSelectedPaths = useWorkspaceStore((state) => state.duplicateSelectedPaths);
   const selectedPathIds = useWorkspaceStore((state) => state.selectedPathIds);
-  const paths = useWorkspaceStore((state) => state.paths);
-  const setPathType = useWorkspaceStore((state) => state.setPathType);
 
   const hasSelection = selectedPathIds.length > 0;
-
-  const selectedPaths = useMemo(
-    () => paths.filter((path) => selectedPathIds.includes(path.meta.id)),
-    [paths, selectedPathIds],
-  );
-
-  const selectionState: PathKind | 'mixed' | null = (() => {
-    if (!selectedPaths.length) return null;
-    const first = selectedPaths[0].meta.kind;
-    return selectedPaths.every((path) => path.meta.kind === first) ? first : 'mixed';
-  })();
 
   return (
     <div className="panel flex flex-col gap-3 p-4">
@@ -62,29 +43,6 @@ export const ToolPanel = () => {
         <span>Copy selection</span>
         <span className="text-[10px] text-muted">⌘D</span>
       </button>
-      <div className="mt-1 text-[11px] uppercase tracking-wide text-muted">Path type</div>
-      {selectionState === 'mixed' && (
-        <div className="rounded-xl border border-dashed border-border px-3 py-2 text-[11px] text-muted">
-          Mixed selection
-        </div>
-      )}
-      <div className="grid grid-cols-2 gap-2">
-        {pathTypes.map((type) => (
-          <button
-            key={type.id}
-            type="button"
-            className={clsx(
-              'toolbar-button h-full text-left',
-              selectionState === type.id && 'toolbar-button-active',
-            )}
-            onClick={() => setPathType(type.id)}
-            disabled={!selectedPaths.length}
-          >
-            <span className="font-semibold">{type.label}</span>
-            <span className="text-[10px] text-muted">{type.description}</span>
-          </button>
-        ))}
-      </div>
     </div>
   );
 };

--- a/src/ui/ToolPanel.tsx
+++ b/src/ui/ToolPanel.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import { useWorkspaceStore } from '../state';
-import type { ToolId } from '../types';
+import type { PathKind, ToolId } from '../types';
 
 const tools: Array<{ id: ToolId; label: string; shortcut: string }> = [
   { id: 'select', label: 'Select', shortcut: 'V' },
@@ -10,11 +10,26 @@ const tools: Array<{ id: ToolId; label: string; shortcut: string }> = [
   { id: 'pan', label: 'Pan', shortcut: 'Space' },
 ];
 
+const pathTypes: Array<{ id: PathKind; label: string; description: string }> = [
+  { id: 'oxided', label: 'Oxided', description: 'Shows oxidation' },
+  { id: 'reference', label: 'Reference', description: 'Reference outline' },
+];
+
 export const ToolPanel = () => {
   const activeTool = useWorkspaceStore((state) => state.activeTool);
   const setActiveTool = useWorkspaceStore((state) => state.setActiveTool);
   const duplicateSelectedPaths = useWorkspaceStore((state) => state.duplicateSelectedPaths);
   const hasSelection = useWorkspaceStore((state) => state.selectedPathIds.length > 0);
+  const selectedPaths = useWorkspaceStore((state) =>
+    state.paths.filter((path) => state.selectedPathIds.includes(path.meta.id)),
+  );
+  const setPathType = useWorkspaceStore((state) => state.setPathType);
+
+  const selectionState: PathKind | 'mixed' | null = (() => {
+    if (!selectedPaths.length) return null;
+    const first = selectedPaths[0].meta.kind;
+    return selectedPaths.every((path) => path.meta.kind === first) ? first : 'mixed';
+  })();
 
   return (
     <div className="panel flex flex-col gap-3 p-4">
@@ -41,6 +56,29 @@ export const ToolPanel = () => {
         <span>Copy selection</span>
         <span className="text-[10px] text-muted">⌘D</span>
       </button>
+      <div className="mt-1 text-[11px] uppercase tracking-wide text-muted">Path type</div>
+      {selectionState === 'mixed' && (
+        <div className="rounded-xl border border-dashed border-border px-3 py-2 text-[11px] text-muted">
+          Mixed selection
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-2">
+        {pathTypes.map((type) => (
+          <button
+            key={type.id}
+            type="button"
+            className={clsx(
+              'toolbar-button h-full text-left',
+              selectionState === type.id && 'toolbar-button-active',
+            )}
+            onClick={() => setPathType(type.id)}
+            disabled={!selectedPaths.length}
+          >
+            <span className="font-semibold">{type.label}</span>
+            <span className="text-[10px] text-muted">{type.description}</span>
+          </button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/utils/dxf.ts
+++ b/src/utils/dxf.ts
@@ -1,0 +1,291 @@
+import type { PathEntity, PathKind, Vec2 } from '../types';
+
+interface RawDXFEntity {
+  points: Vec2[];
+  closed: boolean;
+  layer?: string;
+}
+
+interface ParsedDXFShape {
+  points: Vec2[];
+  closed: boolean;
+  kind: PathKind;
+}
+
+const WORKSPACE_SIZE = 50;
+const WORKSPACE_CENTER = { x: WORKSPACE_SIZE / 2, y: WORKSPACE_SIZE / 2 } as const;
+
+const parseNumber = (value: string): number => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const formatNumber = (value: number): string => {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+  const fixed = value.toFixed(6);
+  return fixed.replace(/\.0+$/, '').replace(/(\.\d*?[1-9])0+$/, '$1');
+};
+
+const buildTokens = (content: string): Array<{ code: number; value: string }> => {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const tokens: Array<{ code: number; value: string }> = [];
+  for (let i = 0; i < lines.length; ) {
+    const rawCode = lines[i]?.trim();
+    i += 1;
+    if (!rawCode) {
+      continue;
+    }
+    const code = Number.parseInt(rawCode, 10);
+    if (!Number.isFinite(code)) {
+      continue;
+    }
+    const rawValue = lines[i] ?? '';
+    i += 1;
+    tokens.push({ code, value: rawValue.trim() });
+  }
+  return tokens;
+};
+
+const centerEntities = (entities: RawDXFEntity[]): RawDXFEntity[] => {
+  const allPoints = entities.flatMap((entity) => entity.points);
+  if (!allPoints.length) {
+    return entities;
+  }
+  const minX = Math.min(...allPoints.map((point) => point.x));
+  const maxX = Math.max(...allPoints.map((point) => point.x));
+  const minY = Math.min(...allPoints.map((point) => point.y));
+  const maxY = Math.max(...allPoints.map((point) => point.y));
+  const center = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
+  const offset = { x: WORKSPACE_CENTER.x - center.x, y: WORKSPACE_CENTER.y - center.y };
+  return entities.map((entity) => ({
+    ...entity,
+    points: entity.points.map((point) => ({ x: point.x + offset.x, y: point.y + offset.y })),
+  }));
+};
+
+const parseLineEntity = (
+  tokens: Array<{ code: number; value: string }>,
+  startIndex: number,
+): { entity: RawDXFEntity | null; nextIndex: number } => {
+  let startX: number | null = null;
+  let startY: number | null = null;
+  let endX: number | null = null;
+  let endY: number | null = null;
+  let layer: string | undefined;
+  let index = startIndex;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token.code === 0) break;
+    switch (token.code) {
+      case 8:
+        layer = token.value.trim();
+        break;
+      case 10:
+        startX = parseNumber(token.value);
+        break;
+      case 20:
+        startY = parseNumber(token.value);
+        break;
+      case 11:
+        endX = parseNumber(token.value);
+        break;
+      case 21:
+        endY = parseNumber(token.value);
+        break;
+      default:
+        break;
+    }
+    index += 1;
+  }
+  if (startX === null || startY === null || endX === null || endY === null) {
+    return { entity: null, nextIndex: index };
+  }
+  return {
+    entity: {
+      points: [
+        { x: startX, y: startY },
+        { x: endX, y: endY },
+      ],
+      closed: false,
+      layer,
+    },
+    nextIndex: index,
+  };
+};
+
+const parseLwpolylineEntity = (
+  tokens: Array<{ code: number; value: string }>,
+  startIndex: number,
+): { entity: RawDXFEntity | null; nextIndex: number } => {
+  const points: Vec2[] = [];
+  let currentX: number | null = null;
+  let closed = false;
+  let layer: string | undefined;
+  let index = startIndex;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token.code === 0) break;
+    switch (token.code) {
+      case 8:
+        layer = token.value.trim();
+        break;
+      case 70: {
+        const flag = Number.parseInt(token.value, 10);
+        if (Number.isFinite(flag)) {
+          closed = (flag & 1) === 1;
+        }
+        break;
+      }
+      case 10:
+        currentX = parseNumber(token.value);
+        break;
+      case 20:
+        if (currentX !== null) {
+          points.push({ x: currentX, y: parseNumber(token.value) });
+          currentX = null;
+        }
+        break;
+      default:
+        break;
+    }
+    index += 1;
+  }
+  if (closed && points.length > 1) {
+    const first = points[0];
+    const last = points[points.length - 1];
+    if (Math.hypot(first.x - last.x, first.y - last.y) <= 1e-6) {
+      points.pop();
+    }
+  }
+  if (points.length < 2) {
+    return { entity: null, nextIndex: index };
+  }
+  return {
+    entity: {
+      points,
+      closed,
+      layer,
+    },
+    nextIndex: index,
+  };
+};
+
+const parseEntities = (tokens: Array<{ code: number; value: string }>): RawDXFEntity[] => {
+  const entities: RawDXFEntity[] = [];
+  let inEntities = false;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.code !== 0) {
+      continue;
+    }
+    const type = token.value.toUpperCase();
+    if (type === 'SECTION') {
+      const next = tokens[i + 1];
+      if (next && next.code === 2 && next.value.toUpperCase() === 'ENTITIES') {
+        inEntities = true;
+      }
+      continue;
+    }
+    if (type === 'ENDSEC') {
+      inEntities = false;
+      continue;
+    }
+    if (!inEntities) {
+      continue;
+    }
+    if (type === 'EOF') {
+      break;
+    }
+    if (type === 'LINE') {
+      const { entity, nextIndex } = parseLineEntity(tokens, i + 1);
+      if (entity) {
+        entities.push(entity);
+      }
+      if (nextIndex > i) {
+        i = nextIndex - 1;
+      }
+      continue;
+    }
+    if (type === 'LWPOLYLINE') {
+      const { entity, nextIndex } = parseLwpolylineEntity(tokens, i + 1);
+      if (entity) {
+        entities.push(entity);
+      }
+      if (nextIndex > i) {
+        i = nextIndex - 1;
+      }
+    }
+  }
+  return entities;
+};
+
+export const parseDXFShapes = (content: string): ParsedDXFShape[] => {
+  const tokens = buildTokens(content);
+  const entities = centerEntities(parseEntities(tokens));
+  return entities.map((entity) => ({
+    points: entity.points.map((point) => ({ ...point })),
+    closed: entity.closed,
+    kind: entity.layer?.toLowerCase() === 'reference' ? 'reference' : 'oxided',
+  }));
+};
+
+export const serializePathsToDXF = (paths: PathEntity[]): string => {
+  const lines: string[] = [
+    '0',
+    'SECTION',
+    '2',
+    'HEADER',
+    '0',
+    'ENDSEC',
+    '0',
+    'SECTION',
+    '2',
+    'ENTITIES',
+  ];
+
+  paths.forEach((path) => {
+    const points = path.nodes.map((node) => node.point);
+    if (points.length < 2) {
+      return;
+    }
+    const layer = path.meta.kind === 'reference' ? 'REFERENCE' : 'OXIDED';
+    if (!path.meta.closed && points.length === 2) {
+      lines.push(
+        '0',
+        'LINE',
+        '8',
+        layer,
+        '10',
+        formatNumber(points[0].x),
+        '20',
+        formatNumber(points[0].y),
+        '11',
+        formatNumber(points[1].x),
+        '21',
+        formatNumber(points[1].y),
+      );
+      return;
+    }
+    const vertices = path.meta.closed ? points : points;
+    lines.push(
+      '0',
+      'LWPOLYLINE',
+      '8',
+      layer,
+      '90',
+      String(vertices.length),
+      '70',
+      path.meta.closed ? '1' : '0',
+    );
+    vertices.forEach((point) => {
+      lines.push('10', formatNumber(point.x), '20', formatNumber(point.y));
+    });
+  });
+
+  lines.push('0', 'ENDSEC', '0', 'EOF');
+  return lines.join('\n');
+};
+
+export type { ParsedDXFShape };


### PR DESCRIPTION
## Summary
- add DXF parsing/serialization helpers and wire DXF import/export buttons into the project panel
- introduce a reference path type with UI controls and state/rendering safeguards that disable oxidation visuals and node edits
- ensure DXF imports are recentred and respect reference layers while keeping saved shapes/library data in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39c7b92fc8324917ba46c2fb4ede3