### PR TITLE
Add scene library and improve DXF curve handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,13 @@ import { useEffect, useRef, type CSSProperties } from 'react';
 import { CanvasViewport } from './ui/CanvasViewport';
 import { DirectionalCompass } from './ui/DirectionalCompass';
 import { ToolPanel } from './ui/ToolPanel';
-import { ScenePanel } from './ui/ScenePanel';
 import { OxidationPanel } from './ui/OxidationPanel';
 import { GridMirrorPanel } from './ui/GridMirrorPanel';
 import { MeasurementPanel } from './ui/MeasurementPanel';
 import { StatusBar } from './ui/StatusBar';
 import { ImportExportPanel } from './ui/ImportExportPanel';
+import { ScenePanel } from './ui/ScenePanel';
+import { PathTypePanel } from './ui/PathTypePanel';
 import { useKeyboardShortcuts } from './ui/useKeyboardShortcuts';
 import { useWorkspaceStore } from './state';
 import { createId } from './utils/ids';
@@ -58,6 +59,7 @@ export const App = () => {
             visible: true,
             locked: false,
             color: '#2563eb',
+            kind: 'oxided',
             createdAt: Date.now(),
             updatedAt: Date.now(),
           },
@@ -84,8 +86,8 @@ export const App = () => {
           <div className="flex flex-col gap-4">
             <DirectionalCompass />
             <ToolPanel />
-            <ScenePanel />
             <ImportExportPanel />
+            <GridMirrorPanel />
           </div>
           <CanvasViewport />
           <div className="flex flex-col items-stretch gap-4">
@@ -96,7 +98,8 @@ export const App = () => {
             {!rightCollapsed && (
               <>
                 <OxidationPanel />
-                <GridMirrorPanel />
+                <PathTypePanel />
+                <ScenePanel />
                 <MeasurementPanel />
               </>
             )}

--- a/src/canvas/contours.ts
+++ b/src/canvas/contours.ts
@@ -66,15 +66,20 @@ export const drawContours = (
     return;
   }
 
-  const strokeColor = selected ? '#2563eb' : path.meta.color;
+  const isReference = path.meta.kind === 'reference';
+  const strokeColor = selected
+    ? '#2563eb'
+    : isReference
+      ? '#94a3b8'
+      : path.meta.color;
 
   const drawVariant = (points: Vec2[], emphasize: boolean) => {
     if (!points.length) return;
     const screenPoints = points.map((point) => worldToCanvas(point, view));
     if (!screenPoints.length) return;
     ctx.save();
-    ctx.globalAlpha = emphasize ? 1 : 0.45;
-    ctx.lineWidth = 1.8;
+    ctx.globalAlpha = emphasize ? 1 : isReference ? 0.35 : 0.45;
+    ctx.lineWidth = isReference ? 1.5 : 1.8;
     ctx.strokeStyle = strokeColor;
     ctx.setLineDash([]);
     strokePolyline(ctx, screenPoints, path.meta.closed);
@@ -208,7 +213,7 @@ export const drawOxidationDots = (
   mirror: MirrorSettings | undefined,
   visible: boolean,
 ): void => {
-  if (!visible) return;
+  if (!visible || path.meta.kind === 'reference') return;
   const samples = path.sampled?.samples;
   if (!samples?.length) return;
 

--- a/src/canvas/handles.ts
+++ b/src/canvas/handles.ts
@@ -8,7 +8,7 @@ export const drawHandles = (
   view: ViewTransform,
   nodeSelection: NodeSelection | null,
 ): void => {
-  if (!selected) return;
+  if (!selected || path.meta.kind === 'reference') return;
   ctx.save();
   ctx.strokeStyle = 'rgba(37, 99, 235, 0.35)';
   ctx.fillStyle = '#2563eb';

--- a/src/canvas/heatmap.ts
+++ b/src/canvas/heatmap.ts
@@ -12,6 +12,7 @@ export const drawHeatmap = (
   path: PathEntity,
   view: ViewTransform,
 ): void => {
+  if (path.meta.kind === 'reference') return;
   const samples = path.sampled?.samples;
   if (!samples?.length) return;
   const values = samples.map((sample) => sample.thickness);

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -82,20 +82,22 @@ export class CanvasRenderer {
 
     state.paths.forEach((path) => {
       const selected = state.selectedPathIds.includes(path.meta.id);
-      if (showHeatmap) {
+      if (showHeatmap && path.meta.kind !== 'reference') {
         drawHeatmap(this.ctx, path, view);
       }
       drawContours(this.ctx, path, selected, view, state.mirror);
-      drawOxidationDots(
-        this.ctx,
-        path,
-        selected,
-        dotCount,
-        progress,
-        view,
-        state.mirror,
-        showDots,
-      );
+      if (path.meta.kind !== 'reference') {
+        drawOxidationDots(
+          this.ctx,
+          path,
+          selected,
+          dotCount,
+          progress,
+          view,
+          state.mirror,
+          showDots,
+        );
+      }
       drawHandles(this.ctx, path, selected, view, state.nodeSelection);
     });
     drawSnaps(this.ctx, state.paths, state.measurements, view);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export type ToolId = 'select' | 'line' | 'dot' | 'measure' | 'pan' | 'erase';
 
+export type PathKind = 'oxided' | 'reference';
+
 export interface Vec2 {
   x: number;
   y: number;
@@ -32,6 +34,7 @@ export interface PathMeta {
   visible: boolean;
   locked: boolean;
   color: string;
+  kind: PathKind;
   createdAt: number;
   updatedAt: number;
 }
@@ -71,6 +74,33 @@ export interface StoredShape {
   name: string;
   nodes: PathNode[];
   oxidation: OxidationSettings;
+  pathType: PathKind;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface StoredSceneState {
+  paths: PathEntity[];
+  selectedPathIds: string[];
+  nodeSelection: NodeSelection | null;
+  activeTool: ToolId;
+  pan: Vec2;
+  zoom: number;
+  grid: GridSettings;
+  mirror: MirrorSettings;
+  oxidationDefaults: OxidationSettings;
+  measurements: MeasurementState;
+  oxidationVisible: boolean;
+  oxidationProgress: number;
+  oxidationDotCount: number;
+  directionalLinking: boolean;
+  panelCollapse: PanelCollapseState;
+}
+
+export interface StoredScene {
+  id: string;
+  name: string;
+  state: StoredSceneState;
   createdAt: number;
   updatedAt: number;
 }
@@ -163,6 +193,7 @@ export interface WorkspaceState {
   directionalLinking: boolean;
   bootstrapped: boolean;
   library: StoredShape[];
+  scenes: StoredScene[];
   zoom: number;
   panelCollapse: PanelCollapseState;
 }

--- a/src/ui/CanvasViewport.tsx
+++ b/src/ui/CanvasViewport.tsx
@@ -20,7 +20,7 @@ type DragTarget =
 const nodeHitThresholdPx = 12;
 const pathHitThresholdPx = 10;
 const MIN_ZOOM = 0.25;
-const MAX_ZOOM = 8;
+const MAX_ZOOM = 4;
 const ZOOM_STEP = 1.1;
 
 const pointSegmentDistance = (p: Vec2, a: Vec2, b: Vec2): number => {
@@ -69,7 +69,7 @@ export const CanvasViewport = () => {
   const penDraft = useRef<{ pathId: string; activeEnd: 'start' | 'end' } | null>(null);
   const [cursorHint, setCursorHint] = useState<string | null>(null);
 
-  const canvasWidthClass = rightSidebarCollapsed ? 'max-w-[1080px]' : 'max-w-[760px]';
+  const canvasWidthClass = rightSidebarCollapsed ? 'max-w-[1080px]' : 'max-w-none';
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -104,6 +104,7 @@ export const CanvasViewport = () => {
     const ordered = orderPathsBySelection(state.paths, state.selectedPathIds);
     const threshold = canvasDistanceToWorld(nodeHitThresholdPx, view);
     for (const path of ordered) {
+      if (path.meta.kind === 'reference') continue;
       for (const node of path.nodes) {
         if (distance(position, node.point) <= threshold) {
           return { kind: 'anchor', pathId: path.meta.id, nodeId: node.id };
@@ -148,6 +149,7 @@ export const CanvasViewport = () => {
     const state = useWorkspaceStore.getState();
     const threshold = canvasDistanceToWorld(pathHitThresholdPx, view);
     for (const path of state.paths) {
+      if (path.meta.kind === 'reference') continue;
       const { nodes } = path;
       const totalSegments = path.meta.closed ? nodes.length : nodes.length - 1;
       if (totalSegments < 1) continue;
@@ -178,6 +180,7 @@ export const CanvasViewport = () => {
     const threshold = canvasDistanceToWorld(pathHitThresholdPx, view);
     let closest: { sample: SamplePoint; distance: number } | null = null;
     for (const path of state.paths) {
+      if (path.meta.kind === 'reference') continue;
       const samples = path.sampled?.samples ?? [];
       for (const sample of samples) {
         const dist = distance(position, sample.position);
@@ -232,6 +235,7 @@ export const CanvasViewport = () => {
     }
 
     for (const path of state.paths) {
+      if (path.meta.kind === 'reference') continue;
       if (path.nodes.length !== 1) continue;
       const center = path.nodes[0].point;
       const delta = {
@@ -285,6 +289,10 @@ export const CanvasViewport = () => {
     const closeThreshold = canvasDistanceToWorld(nodeHitThresholdPx + 4, view);
     const segmentHit = hitTestSegment(position, view);
     if (segmentHit) {
+      const path = state.paths.find((entry) => entry.meta.id === segmentHit.pathId);
+      if (!path || path.meta.kind === 'reference') {
+        return;
+      }
       const newNode = {
         id: createId('node'),
         point: position,
@@ -317,6 +325,7 @@ export const CanvasViewport = () => {
             visible: true,
             locked: false,
             color: '#2563eb',
+            kind: 'oxided',
             createdAt: Date.now(),
             updatedAt: Date.now(),
           },
@@ -420,6 +429,7 @@ export const CanvasViewport = () => {
           visible: true,
           locked: false,
           color: '#2563eb',
+          kind: 'oxided',
           createdAt: Date.now(),
           updatedAt: Date.now(),
         },
@@ -440,7 +450,11 @@ export const CanvasViewport = () => {
       }
       const segment = hitTestSegment(position, view);
       if (segment && event.detail >= 2) {
-        toggleSegmentCurve(segment.pathId, segment.segmentIndex);
+        const state = useWorkspaceStore.getState();
+        const path = state.paths.find((entry) => entry.meta.id === segment.pathId);
+        if (path?.meta.kind !== 'reference') {
+          toggleSegmentCurve(segment.pathId, segment.segmentIndex);
+        }
         setSelected([segment.pathId]);
         return;
       }

--- a/src/ui/ImportExportPanel.tsx
+++ b/src/ui/ImportExportPanel.tsx
@@ -1,13 +1,51 @@
 import { useRef, type ChangeEvent } from 'react';
-import { exportProjectToJSON, importProjectFromJSON, exportProjectToPNG, exportProjectToSVG } from '../utils/io';
+import {
+  exportProjectToJSON,
+  importProjectFromJSON,
+  exportProjectToPNG,
+  exportProjectToSVG,
+} from '../utils/io';
+import { parseDXFShapes, serializePathsToDXF } from '../utils/dxf';
 import { useWorkspaceStore } from '../state';
+import { createId } from '../utils/ids';
+import { createArcNodes, createCircleNodes } from '../utils/presets';
+
+type ParsedDXFShape = ReturnType<typeof parseDXFShapes>[number];
+
+const buildNodesFromDXFShape = (shape: ParsedDXFShape) => {
+  if (shape.source === 'circle' && shape.center && Number.isFinite(shape.radius)) {
+    return createCircleNodes(shape.center, shape.radius ?? 0);
+  }
+  if (
+    shape.source === 'arc' &&
+    shape.center &&
+    Number.isFinite(shape.radius) &&
+    Number.isFinite(shape.startAngle ?? NaN) &&
+    Number.isFinite(shape.sweep ?? NaN)
+  ) {
+    const nodes = createArcNodes(shape.center, shape.radius ?? 0, shape.startAngle ?? 0, shape.sweep ?? 0);
+    if (nodes.length >= 2) {
+      return nodes;
+    }
+  }
+  return shape.points.map((point) => ({
+    id: createId('node'),
+    point: { ...point },
+    handleIn: null,
+    handleOut: null,
+  }));
+};
 
 export const ImportExportPanel = () => {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const dxfInputRef = useRef<HTMLInputElement | null>(null);
   const undo = useWorkspaceStore((state) => state.undo);
   const redo = useWorkspaceStore((state) => state.redo);
   const importState = useWorkspaceStore((state) => state.importState);
   const pushWarning = useWorkspaceStore((state) => state.pushWarning);
+  const addPath = useWorkspaceStore((state) => state.addPath);
+  const setSelected = useWorkspaceStore((state) => state.setSelected);
+  const setNodeSelection = useWorkspaceStore((state) => state.setNodeSelection);
   const getState = useWorkspaceStore.getState;
 
   const handleExportJSON = () => {
@@ -31,6 +69,7 @@ export const ImportExportPanel = () => {
       console.error(error);
       pushWarning('Failed to import JSON', 'error');
     }
+    event.target.value = '';
   };
 
   const handleExportPNG = async () => {
@@ -51,6 +90,64 @@ export const ImportExportPanel = () => {
     URL.revokeObjectURL(link.href);
   };
 
+  const handleExportDXF = () => {
+    const { paths } = getState();
+    if (!paths.length) {
+      pushWarning('Nothing to export', 'warning');
+      return;
+    }
+    const dxf = serializePathsToDXF(paths);
+    const blob = new Blob([dxf], { type: 'application/dxf' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'visoxid-scene.dxf';
+    link.click();
+    URL.revokeObjectURL(link.href);
+  };
+
+  const handleImportDXF = async (event: ChangeEvent<HTMLInputElement>) => {
+    const [file] = event.target.files ?? [];
+    if (!file) return;
+    const text = await file.text();
+    try {
+      const shapes = parseDXFShapes(text);
+      if (!shapes.length) {
+        pushWarning('DXF contained no supported entities', 'warning');
+        return;
+      }
+      const ids: string[] = [];
+      shapes.forEach((shape, index) => {
+        const nodes = buildNodesFromDXFShape(shape);
+        if (nodes.length < 2) {
+          return;
+        }
+        const metaId = createId('path');
+        const pathId = addPath(nodes, {
+          meta: {
+            id: metaId,
+            name: `${shape.kind === 'reference' ? 'Reference' : 'Imported'} ${index + 1}`,
+            closed: shape.closed,
+            visible: true,
+            locked: false,
+            color: '#2563eb',
+            kind: shape.kind,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        });
+        ids.push(pathId);
+      });
+      if (ids.length) {
+        setSelected(ids);
+        setNodeSelection(null);
+      }
+    } catch (error) {
+      console.error(error);
+      pushWarning('Failed to import DXF', 'error');
+    }
+    event.target.value = '';
+  };
+
   return (
     <div className="panel flex flex-col gap-3 p-4 text-xs text-muted">
       <div className="section-title">Project</div>
@@ -67,8 +164,15 @@ export const ImportExportPanel = () => {
         <button type="button" className="toolbar-button" onClick={handleExportSVG}>
           SVG stub
         </button>
+        <button type="button" className="toolbar-button" onClick={handleExportDXF}>
+          Export DXF
+        </button>
+        <button type="button" className="toolbar-button" onClick={() => dxfInputRef.current?.click()}>
+          Import DXF
+        </button>
       </div>
       <input ref={inputRef} type="file" accept="application/json" className="hidden" onChange={handleImportJSON} />
+      <input ref={dxfInputRef} type="file" accept=".dxf" className="hidden" onChange={handleImportDXF} />
       <div className="mt-2 flex items-center justify-between">
         <button type="button" className="toolbar-button" onClick={undo}>
           Undo

--- a/src/ui/PathTypePanel.tsx
+++ b/src/ui/PathTypePanel.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { clsx } from 'clsx';
+import { useWorkspaceStore } from '../state';
+import type { PathKind } from '../types';
+
+const pathTypes: Array<{ id: PathKind; label: string; description: string }> = [
+  { id: 'oxided', label: 'Oxided', description: 'Shows oxidation' },
+  { id: 'reference', label: 'Reference', description: 'Reference outline' },
+];
+
+export const PathTypePanel = () => {
+  const paths = useWorkspaceStore((state) => state.paths);
+  const selectedPathIds = useWorkspaceStore((state) => state.selectedPathIds);
+  const setPathType = useWorkspaceStore((state) => state.setPathType);
+
+  const selectedPaths = useMemo(
+    () => paths.filter((path) => selectedPathIds.includes(path.meta.id)),
+    [paths, selectedPathIds],
+  );
+
+  const selectionState: PathKind | 'mixed' | null = (() => {
+    if (!selectedPaths.length) return null;
+    const first = selectedPaths[0].meta.kind;
+    return selectedPaths.every((path) => path.meta.kind === first) ? first : 'mixed';
+  })();
+
+  return (
+    <div className="panel flex flex-col gap-3 p-4">
+      <div className="section-title">Path type</div>
+      {selectionState === 'mixed' && (
+        <div className="rounded-xl border border-dashed border-border px-3 py-2 text-[11px] text-muted">
+          Mixed selection
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-2">
+        {pathTypes.map((type) => (
+          <button
+            key={type.id}
+            type="button"
+            className={clsx(
+              'toolbar-button h-full text-left',
+              selectionState === type.id && 'toolbar-button-active',
+            )}
+            onClick={() => setPathType(type.id)}
+            disabled={!selectedPaths.length}
+          >
+            <span className="font-semibold">{type.label}</span>
+            <span className="text-[10px] text-muted">{type.description}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PathTypePanel;

--- a/src/ui/ScenePanel.tsx
+++ b/src/ui/ScenePanel.tsx
@@ -7,17 +7,25 @@ export const ScenePanel = () => {
   const selectedPathIds = useWorkspaceStore((state) => state.selectedPathIds);
   const paths = useWorkspaceStore((state) => state.paths);
   const saveShape = useWorkspaceStore((state) => state.saveShapeToLibrary);
+  const saveScene = useWorkspaceStore((state) => state.saveSceneToLibrary);
   const removeShape = useWorkspaceStore((state) => state.removeShapeFromLibrary);
+  const removeScene = useWorkspaceStore((state) => state.removeSceneFromLibrary);
   const renameShape = useWorkspaceStore((state) => state.renameShapeInLibrary);
+  const renameScene = useWorkspaceStore((state) => state.renameSceneInLibrary);
   const loadShape = useWorkspaceStore((state) => state.loadShapeFromLibrary);
+  const loadStoredScene = useWorkspaceStore((state) => state.loadSceneFromLibrary);
   const resetScene = useWorkspaceStore((state) => state.resetScene);
   const removePath = useWorkspaceStore((state) => state.removePath);
   const addPath = useWorkspaceStore((state) => state.addPath);
+  const pushWarning = useWorkspaceStore((state) => state.pushWarning);
   const nodeSelection = useWorkspaceStore((state) => state.nodeSelection);
   const setNodeCurveMode = useWorkspaceStore((state) => state.setNodeCurveMode);
   const library = useWorkspaceStore((state) => state.library);
-  const [shapeName, setShapeName] = useState('');
-  const [renameDrafts, setRenameDrafts] = useState<Record<string, string>>({});
+  const scenes = useWorkspaceStore((state) => state.scenes);
+  const [saveName, setSaveName] = useState('');
+  const [referenceCircleDiameter, setReferenceCircleDiameter] = useState('36');
+  const [shapeRenameDrafts, setShapeRenameDrafts] = useState<Record<string, string>>({});
+  const [sceneRenameDrafts, setSceneRenameDrafts] = useState<Record<string, string>>({});
 
   const selectedPath = paths.find((path) => path.meta.id === selectedPathIds[0]);
   const activeNodeId =
@@ -40,41 +48,77 @@ export const ScenePanel = () => {
       (hasNextSegment && Boolean(selectedPath.nodes[nextIndex]?.handleIn))
     );
   })();
-  const handleSave = () => {
+
+  const handleShapeSave = () => {
     if (!selectedPath) return;
-    saveShape(selectedPath.meta.id, shapeName || selectedPath.meta.name);
-    setShapeName('');
+    saveShape(selectedPath.meta.id, saveName || selectedPath.meta.name);
   };
 
-  const handleRenameCommit = (id: string) => {
-    const draft = renameDrafts[id];
+  const handleSceneSave = () => {
+    const fallback = selectedPath?.meta.name ?? 'Untitled scene';
+    saveScene(saveName || fallback);
+  };
+
+  const handleShapeRenameCommit = (id: string) => {
+    const draft = shapeRenameDrafts[id];
     if (draft !== undefined) {
       renameShape(id, draft);
     }
   };
 
+  const handleSceneRenameCommit = (id: string) => {
+    const draft = sceneRenameDrafts[id];
+    if (draft !== undefined) {
+      renameScene(id, draft);
+    }
+  };
+
+  const handleAddReferenceCircle = () => {
+    const diameter = Number.parseFloat(referenceCircleDiameter);
+    if (!Number.isFinite(diameter) || diameter <= 0) {
+      pushWarning('Enter a positive diameter before adding the circle', 'warning');
+      return;
+    }
+    const radius = diameter / 2;
+    const normalized = Math.round(diameter * 10) / 10;
+    const label = Number.isInteger(normalized) ? normalized.toFixed(0) : normalized.toFixed(1);
+    addPath(createCircleNodes({ x: 25, y: 25 }, radius), {
+      meta: {
+        id: createId('path'),
+        name: `Reference circle (${label} μm)`,
+        closed: true,
+        visible: true,
+        locked: false,
+        color: '#2563eb',
+        kind: 'reference',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    });
+  };
+
   return (
     <div className="panel flex flex-col gap-4 p-4 text-xs text-muted">
       <div className="section-title">Scene</div>
-      <div className="flex flex-col gap-2 text-xs">
+      <div className="flex flex-col gap-3 text-xs">
         <label className="flex flex-col gap-1">
-          <span className="text-[11px] uppercase tracking-wide text-muted">Shape name</span>
+          <span className="text-[11px] uppercase tracking-wide text-muted">Name</span>
           <input
             type="text"
-            value={shapeName}
-            onChange={(event) => setShapeName(event.target.value)}
-            placeholder={selectedPath ? selectedPath.meta.name : 'Select a path'}
+            value={saveName}
+            onChange={(event) => setSaveName(event.target.value)}
+            placeholder={selectedPath ? selectedPath.meta.name : 'Untitled'}
             className="rounded-xl border border-border bg-white/80 px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
           />
         </label>
-        <button
-          type="button"
-          className="toolbar-button"
-          onClick={handleSave}
-          disabled={!selectedPath}
-        >
-          Save shape to library
-        </button>
+        <div className="grid grid-cols-2 gap-2">
+          <button type="button" className="toolbar-button" onClick={handleShapeSave} disabled={!selectedPath}>
+            Save shape
+          </button>
+          <button type="button" className="toolbar-button" onClick={handleSceneSave} disabled={paths.length === 0}>
+            Save scene
+          </button>
+        </div>
         <button
           type="button"
           className="toolbar-button"
@@ -88,33 +132,26 @@ export const ScenePanel = () => {
           className="toolbar-button"
           onClick={() => {
             resetScene();
-            setShapeName('');
           }}
         >
           Reset canvas
         </button>
-        <button
-          type="button"
-          className="toolbar-button"
-          onClick={() =>
-            addPath(createCircleNodes({ x: 25, y: 25 }, 18), {
-              meta: {
-                id: createId('path'),
-                name: 'Reference circle',
-                closed: true,
-                visible: true,
-                locked: false,
-                color: '#2563eb',
-                createdAt: Date.now(),
-                updatedAt: Date.now(),
-              },
-            })
-          }
-        >
+        <button type="button" className="toolbar-button" onClick={handleAddReferenceCircle}>
           Add reference circle
         </button>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] uppercase tracking-wide text-muted">Circle diameter (μm)</span>
+          <input
+            type="number"
+            min="0"
+            step="0.5"
+            value={referenceCircleDiameter}
+            onChange={(event) => setReferenceCircleDiameter(event.target.value)}
+            className="rounded-xl border border-border bg-white/80 px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
+          />
+        </label>
       </div>
-      {selectedPath && activeNode && (
+      {selectedPath && activeNode && selectedPath.meta.kind !== 'reference' && (
         <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-border/70 bg-white/70 p-3 text-xs text-muted">
           <div className="text-[11px] uppercase tracking-wide text-muted">Selected node</div>
           <div className="flex justify-between text-[11px] font-semibold text-text">
@@ -148,51 +185,109 @@ export const ScenePanel = () => {
         </div>
       )}
       <div className="rounded-2xl border border-dashed border-border/70 bg-white/60 p-3">
-        {library.length === 0 ? (
-          <div className="text-xs">Saved shapes will appear here. Capture any contour to reuse it later.</div>
-        ) : (
-          <ul className="flex flex-col gap-2">
-            {library.map((shape) => (
-              <li key={shape.id} className="flex flex-col gap-2 rounded-xl bg-white/80 p-3 shadow-sm">
-                <div className="flex items-center gap-2">
-                  <input
-                    type="text"
-                    defaultValue={shape.name}
-                    onChange={(event) =>
-                      setRenameDrafts((drafts) => ({ ...drafts, [shape.id]: event.target.value }))
-                    }
-                    onBlur={() => handleRenameCommit(shape.id)}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        handleRenameCommit(shape.id);
-                        event.currentTarget.blur();
-                      }
-                    }}
-                    className="flex-1 rounded-lg border border-border bg-white/80 px-2 py-1 text-sm text-text focus:border-accent focus:outline-none"
-                  />
-                  <button
-                    type="button"
-                    className="rounded-lg border border-accent px-2 py-1 text-[11px] font-semibold text-accent hover:bg-accent/10"
-                    onClick={() => loadShape(shape.id)}
-                  >
-                    Load
-                  </button>
-                  <button
-                    type="button"
-                    className="rounded-lg border border-border px-2 py-1 text-[11px] text-muted hover:bg-border/20"
-                    onClick={() => removeShape(shape.id)}
-                  >
-                    Delete
-                  </button>
-                </div>
-                <div className="flex justify-between text-[10px] uppercase tracking-widest text-muted">
-                  <span>{shape.nodes.length} pts</span>
-                  <span>Saved {new Date(shape.updatedAt).toLocaleDateString()}</span>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
+        <div className="flex flex-col gap-2">
+          <div className="text-[11px] uppercase tracking-wide text-muted">Saved scenes</div>
+          {scenes.length === 0 ? (
+            <div className="text-xs">Capture a scene to preserve the full workspace configuration.</div>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {scenes.map((scene) => {
+                const draft = sceneRenameDrafts[scene.id] ?? scene.name;
+                return (
+                  <li key={scene.id} className="flex flex-col gap-2 rounded-xl bg-white/80 p-3 shadow-sm">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <input
+                        type="text"
+                        value={draft}
+                        onChange={(event) =>
+                          setSceneRenameDrafts((drafts) => ({ ...drafts, [scene.id]: event.target.value }))
+                        }
+                        onBlur={() => handleSceneRenameCommit(scene.id)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            handleSceneRenameCommit(scene.id);
+                            event.currentTarget.blur();
+                          }
+                        }}
+                        className="min-w-[140px] flex-1 rounded-lg border border-border bg-white/80 px-2 py-1 text-sm text-text focus:border-accent focus:outline-none"
+                      />
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-lg border border-accent px-2 py-1 text-[11px] font-semibold text-accent hover:bg-accent/10"
+                        onClick={() => loadStoredScene(scene.id)}
+                      >
+                        Load
+                      </button>
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-lg border border-border px-2 py-1 text-[11px] text-muted hover:bg-border/20"
+                        onClick={() => removeScene(scene.id)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                    <div className="flex flex-wrap justify-between gap-2 text-[10px] uppercase tracking-widest text-muted">
+                      <span>{scene.state.paths.length} paths</span>
+                      <span>Saved {new Date(scene.updatedAt).toLocaleDateString()}</span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+        <div className="my-3 h-px bg-border/60" />
+        <div className="flex flex-col gap-2">
+          <div className="text-[11px] uppercase tracking-wide text-muted">Saved shapes</div>
+          {library.length === 0 ? (
+            <div className="text-xs">Saved shapes will appear here. Capture any contour to reuse it later.</div>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {library.map((shape) => {
+                const draft = shapeRenameDrafts[shape.id] ?? shape.name;
+                return (
+                  <li key={shape.id} className="flex flex-col gap-2 rounded-xl bg-white/80 p-3 shadow-sm">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <input
+                        type="text"
+                        value={draft}
+                        onChange={(event) =>
+                          setShapeRenameDrafts((drafts) => ({ ...drafts, [shape.id]: event.target.value }))
+                        }
+                        onBlur={() => handleShapeRenameCommit(shape.id)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            handleShapeRenameCommit(shape.id);
+                            event.currentTarget.blur();
+                          }
+                        }}
+                        className="min-w-[140px] flex-1 rounded-lg border border-border bg-white/80 px-2 py-1 text-sm text-text focus:border-accent focus:outline-none"
+                      />
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-lg border border-accent px-2 py-1 text-[11px] font-semibold text-accent hover:bg-accent/10"
+                        onClick={() => loadShape(shape.id)}
+                      >
+                        Load
+                      </button>
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-lg border border-border px-2 py-1 text-[11px] text-muted hover:bg-border/20"
+                        onClick={() => removeShape(shape.id)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                    <div className="flex flex-wrap justify-between gap-2 text-[10px] uppercase tracking-widest text-muted">
+                      <span>{shape.nodes.length} pts</span>
+                      <span>Saved {new Date(shape.updatedAt).toLocaleDateString()}</span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/ui/ToolPanel.tsx
+++ b/src/ui/ToolPanel.tsx
@@ -14,7 +14,9 @@ export const ToolPanel = () => {
   const activeTool = useWorkspaceStore((state) => state.activeTool);
   const setActiveTool = useWorkspaceStore((state) => state.setActiveTool);
   const duplicateSelectedPaths = useWorkspaceStore((state) => state.duplicateSelectedPaths);
-  const hasSelection = useWorkspaceStore((state) => state.selectedPathIds.length > 0);
+  const selectedPathIds = useWorkspaceStore((state) => state.selectedPathIds);
+
+  const hasSelection = selectedPathIds.length > 0;
 
   return (
     <div className="panel flex flex-col gap-3 p-4">
@@ -31,16 +33,16 @@ export const ToolPanel = () => {
             <span className="text-[10px] text-muted">{tool.shortcut}</span>
           </button>
         ))}
+        <button
+          type="button"
+          className="toolbar-button"
+          onClick={() => duplicateSelectedPaths()}
+          disabled={!hasSelection}
+        >
+          <span>Copy</span>
+          <span className="text-[10px] text-muted">⌘D</span>
+        </button>
       </div>
-      <button
-        type="button"
-        className="toolbar-button"
-        onClick={() => duplicateSelectedPaths()}
-        disabled={!hasSelection}
-      >
-        <span>Copy selection</span>
-        <span className="text-[10px] text-muted">⌘D</span>
-      </button>
     </div>
   );
 };

--- a/src/utils/dxf.ts
+++ b/src/utils/dxf.ts
@@ -1,0 +1,480 @@
+import type { PathEntity, PathKind, Vec2 } from '../types';
+
+type RawDXFEntityType = 'polyline' | 'circle' | 'arc';
+
+interface RawDXFEntity {
+  points: Vec2[];
+  closed: boolean;
+  layer?: string;
+  type: RawDXFEntityType;
+  center?: Vec2;
+  radius?: number;
+  startAngle?: number;
+  sweep?: number;
+}
+
+interface ParsedDXFShape {
+  points: Vec2[];
+  closed: boolean;
+  kind: PathKind;
+  source: RawDXFEntityType;
+  center?: Vec2;
+  radius?: number;
+  startAngle?: number;
+  sweep?: number;
+}
+
+const WORKSPACE_SIZE = 50;
+const WORKSPACE_CENTER = { x: WORKSPACE_SIZE / 2, y: WORKSPACE_SIZE / 2 } as const;
+const DEGREES_TO_RADIANS = Math.PI / 180;
+const TAU = Math.PI * 2;
+
+const parseNumber = (value: string): number => {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const formatNumber = (value: number): string => {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+  const fixed = value.toFixed(6);
+  return fixed.replace(/\.0+$/, '').replace(/(\.\d*?[1-9])0+$/, '$1');
+};
+
+const buildTokens = (content: string): Array<{ code: number; value: string }> => {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const tokens: Array<{ code: number; value: string }> = [];
+  for (let i = 0; i < lines.length; ) {
+    const rawCode = lines[i]?.trim();
+    i += 1;
+    if (!rawCode) {
+      continue;
+    }
+    const code = Number.parseInt(rawCode, 10);
+    if (!Number.isFinite(code)) {
+      continue;
+    }
+    const rawValue = lines[i] ?? '';
+    i += 1;
+    tokens.push({ code, value: rawValue.trim() });
+  }
+  return tokens;
+};
+
+const centerEntities = (entities: RawDXFEntity[]): RawDXFEntity[] => {
+  const allPoints = entities.flatMap((entity) => entity.points);
+  if (!allPoints.length) {
+    return entities;
+  }
+  const minX = Math.min(...allPoints.map((point) => point.x));
+  const maxX = Math.max(...allPoints.map((point) => point.x));
+  const minY = Math.min(...allPoints.map((point) => point.y));
+  const maxY = Math.max(...allPoints.map((point) => point.y));
+  const center = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
+  const offset = { x: WORKSPACE_CENTER.x - center.x, y: WORKSPACE_CENTER.y - center.y };
+  return entities.map((entity) => ({
+    ...entity,
+    points: entity.points.map((point) => ({ x: point.x + offset.x, y: point.y + offset.y })),
+    center: entity.center
+      ? { x: entity.center.x + offset.x, y: entity.center.y + offset.y }
+      : entity.center,
+  }));
+};
+
+const parseLineEntity = (
+  tokens: Array<{ code: number; value: string }>,
+  startIndex: number,
+): { entity: RawDXFEntity | null; nextIndex: number } => {
+  let startX: number | null = null;
+  let startY: number | null = null;
+  let endX: number | null = null;
+  let endY: number | null = null;
+  let layer: string | undefined;
+  let index = startIndex;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token.code === 0) break;
+    switch (token.code) {
+      case 8:
+        layer = token.value.trim();
+        break;
+      case 10:
+        startX = parseNumber(token.value);
+        break;
+      case 20:
+        startY = parseNumber(token.value);
+        break;
+      case 11:
+        endX = parseNumber(token.value);
+        break;
+      case 21:
+        endY = parseNumber(token.value);
+        break;
+      default:
+        break;
+    }
+    index += 1;
+  }
+  if (startX === null || startY === null || endX === null || endY === null) {
+    return { entity: null, nextIndex: index };
+  }
+  return {
+    entity: {
+      points: [
+        { x: startX, y: startY },
+        { x: endX, y: endY },
+      ],
+      closed: false,
+      layer,
+      type: 'polyline',
+    },
+    nextIndex: index,
+  };
+};
+
+const parseLwpolylineEntity = (
+  tokens: Array<{ code: number; value: string }>,
+  startIndex: number,
+): { entity: RawDXFEntity | null; nextIndex: number } => {
+  const points: Vec2[] = [];
+  let currentX: number | null = null;
+  let closed = false;
+  let layer: string | undefined;
+  let index = startIndex;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token.code === 0) break;
+    switch (token.code) {
+      case 8:
+        layer = token.value.trim();
+        break;
+      case 70: {
+        const flag = Number.parseInt(token.value, 10);
+        if (Number.isFinite(flag)) {
+          closed = (flag & 1) === 1;
+        }
+        break;
+      }
+      case 10:
+        currentX = parseNumber(token.value);
+        break;
+      case 20:
+        if (currentX !== null) {
+          points.push({ x: currentX, y: parseNumber(token.value) });
+          currentX = null;
+        }
+        break;
+      default:
+        break;
+    }
+    index += 1;
+  }
+  if (closed && points.length > 1) {
+    const first = points[0];
+    const last = points[points.length - 1];
+    if (Math.hypot(first.x - last.x, first.y - last.y) <= 1e-6) {
+      points.pop();
+    }
+  }
+  if (points.length < 2) {
+    return { entity: null, nextIndex: index };
+  }
+  return {
+    entity: {
+      points,
+      closed,
+      layer,
+      type: 'polyline',
+    },
+    nextIndex: index,
+  };
+};
+
+const sampleArcPoints = (
+  center: Vec2,
+  radius: number,
+  startAngle: number,
+  sweep: number,
+  closed: boolean,
+): Vec2[] => {
+  const fraction = Math.min(1, Math.max(sweep / TAU, 0));
+  const baseSegments = 64;
+  const minimum = closed ? 16 : 8;
+  const segments = Math.max(minimum, Math.ceil(fraction * baseSegments));
+  const points: Vec2[] = [];
+  if (closed) {
+    for (let i = 0; i < segments; i += 1) {
+      const angle = startAngle + (sweep * i) / segments;
+      points.push({
+        x: center.x + Math.cos(angle) * radius,
+        y: center.y + Math.sin(angle) * radius,
+      });
+    }
+  } else {
+    for (let i = 0; i <= segments; i += 1) {
+      const angle = startAngle + (sweep * i) / segments;
+      points.push({
+        x: center.x + Math.cos(angle) * radius,
+        y: center.y + Math.sin(angle) * radius,
+      });
+    }
+  }
+  return points;
+};
+
+const parseArcEntity = (
+  tokens: Array<{ code: number; value: string }>,
+  startIndex: number,
+): { entity: RawDXFEntity | null; nextIndex: number } => {
+  let centerX: number | null = null;
+  let centerY: number | null = null;
+  let radius: number | null = null;
+  let startAngleDeg: number | null = null;
+  let endAngleDeg: number | null = null;
+  let layer: string | undefined;
+  let index = startIndex;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token.code === 0) break;
+    switch (token.code) {
+      case 8:
+        layer = token.value.trim();
+        break;
+      case 10:
+        centerX = parseNumber(token.value);
+        break;
+      case 20:
+        centerY = parseNumber(token.value);
+        break;
+      case 40:
+        radius = parseNumber(token.value);
+        break;
+      case 50:
+        startAngleDeg = parseNumber(token.value);
+        break;
+      case 51:
+        endAngleDeg = parseNumber(token.value);
+        break;
+      default:
+        break;
+    }
+    index += 1;
+  }
+  if (centerX === null || centerY === null || radius === null || radius <= 0) {
+    return { entity: null, nextIndex: index };
+  }
+  const start = (startAngleDeg ?? 0) * DEGREES_TO_RADIANS;
+  const end = (endAngleDeg ?? startAngleDeg ?? 0) * DEGREES_TO_RADIANS;
+  let sweep = end - start;
+  if (!Number.isFinite(sweep) || Math.abs(sweep) < 1e-9) {
+    sweep = TAU;
+  }
+  while (sweep <= 0) {
+    sweep += TAU;
+  }
+  return {
+    entity: {
+      points: sampleArcPoints({ x: centerX, y: centerY }, radius, start, sweep, false),
+      closed: false,
+      layer,
+      type: 'arc',
+      center: { x: centerX, y: centerY },
+      radius,
+      startAngle: start,
+      sweep,
+    },
+    nextIndex: index,
+  };
+};
+
+const parseCircleEntity = (
+  tokens: Array<{ code: number; value: string }>,
+  startIndex: number,
+): { entity: RawDXFEntity | null; nextIndex: number } => {
+  let centerX: number | null = null;
+  let centerY: number | null = null;
+  let radius: number | null = null;
+  let layer: string | undefined;
+  let index = startIndex;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token.code === 0) break;
+    switch (token.code) {
+      case 8:
+        layer = token.value.trim();
+        break;
+      case 10:
+        centerX = parseNumber(token.value);
+        break;
+      case 20:
+        centerY = parseNumber(token.value);
+        break;
+      case 40:
+        radius = parseNumber(token.value);
+        break;
+      default:
+        break;
+    }
+    index += 1;
+  }
+  if (centerX === null || centerY === null || radius === null || radius <= 0) {
+    return { entity: null, nextIndex: index };
+  }
+  return {
+    entity: {
+      points: sampleArcPoints({ x: centerX, y: centerY }, radius, 0, TAU, true),
+      closed: true,
+      layer,
+      type: 'circle',
+      center: { x: centerX, y: centerY },
+      radius,
+      startAngle: 0,
+      sweep: TAU,
+    },
+    nextIndex: index,
+  };
+};
+
+const parseEntities = (tokens: Array<{ code: number; value: string }>): RawDXFEntity[] => {
+  const entities: RawDXFEntity[] = [];
+  let inEntities = false;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token.code !== 0) {
+      continue;
+    }
+    const type = token.value.toUpperCase();
+    if (type === 'SECTION') {
+      const next = tokens[i + 1];
+      if (next && next.code === 2 && next.value.toUpperCase() === 'ENTITIES') {
+        inEntities = true;
+      }
+      continue;
+    }
+    if (type === 'ENDSEC') {
+      inEntities = false;
+      continue;
+    }
+    if (!inEntities) {
+      continue;
+    }
+    if (type === 'EOF') {
+      break;
+    }
+    if (type === 'LINE') {
+      const { entity, nextIndex } = parseLineEntity(tokens, i + 1);
+      if (entity) {
+        entities.push(entity);
+      }
+      if (nextIndex > i) {
+        i = nextIndex - 1;
+      }
+      continue;
+    }
+    if (type === 'LWPOLYLINE') {
+      const { entity, nextIndex } = parseLwpolylineEntity(tokens, i + 1);
+      if (entity) {
+        entities.push(entity);
+      }
+      if (nextIndex > i) {
+        i = nextIndex - 1;
+      }
+      continue;
+    }
+    if (type === 'ARC') {
+      const { entity, nextIndex } = parseArcEntity(tokens, i + 1);
+      if (entity) {
+        entities.push(entity);
+      }
+      if (nextIndex > i) {
+        i = nextIndex - 1;
+      }
+      continue;
+    }
+    if (type === 'CIRCLE') {
+      const { entity, nextIndex } = parseCircleEntity(tokens, i + 1);
+      if (entity) {
+        entities.push(entity);
+      }
+      if (nextIndex > i) {
+        i = nextIndex - 1;
+      }
+    }
+  }
+  return entities;
+};
+
+export const parseDXFShapes = (content: string): ParsedDXFShape[] => {
+  const tokens = buildTokens(content);
+  const entities = centerEntities(parseEntities(tokens));
+  return entities.map((entity) => ({
+    points: entity.points.map((point) => ({ ...point })),
+    closed: entity.closed,
+    kind: entity.layer?.toLowerCase() === 'reference' ? 'reference' : 'oxided',
+    source: entity.type,
+    center: entity.center ? { ...entity.center } : undefined,
+    radius: entity.radius,
+    startAngle: entity.startAngle,
+    sweep: entity.sweep,
+  }));
+};
+
+export const serializePathsToDXF = (paths: PathEntity[]): string => {
+  const lines: string[] = [
+    '0',
+    'SECTION',
+    '2',
+    'HEADER',
+    '0',
+    'ENDSEC',
+    '0',
+    'SECTION',
+    '2',
+    'ENTITIES',
+  ];
+
+  paths.forEach((path) => {
+    const points = path.nodes.map((node) => node.point);
+    if (points.length < 2) {
+      return;
+    }
+    const layer = path.meta.kind === 'reference' ? 'REFERENCE' : 'OXIDED';
+    if (!path.meta.closed && points.length === 2) {
+      lines.push(
+        '0',
+        'LINE',
+        '8',
+        layer,
+        '10',
+        formatNumber(points[0].x),
+        '20',
+        formatNumber(points[0].y),
+        '11',
+        formatNumber(points[1].x),
+        '21',
+        formatNumber(points[1].y),
+      );
+      return;
+    }
+    const vertices = path.meta.closed ? points : points;
+    lines.push(
+      '0',
+      'LWPOLYLINE',
+      '8',
+      layer,
+      '90',
+      String(vertices.length),
+      '70',
+      path.meta.closed ? '1' : '0',
+    );
+    vertices.forEach((point) => {
+      lines.push('10', formatNumber(point.x), '20', formatNumber(point.y));
+    });
+  });
+
+  lines.push('0', 'ENDSEC', '0', 'EOF');
+  return lines.join('\n');
+};
+
+export type { ParsedDXFShape };

--- a/src/utils/presets.ts
+++ b/src/utils/presets.ts
@@ -1,5 +1,5 @@
 import { createId } from './ids';
-import type { PathNode } from '../types';
+import type { PathNode, Vec2 } from '../types';
 
 export const createCircleNodes = (center: { x: number; y: number }, radius: number): PathNode[] => {
   const k = radius * 0.5522847498307936;
@@ -29,4 +29,61 @@ export const createCircleNodes = (center: { x: number; y: number }, radius: numb
       handleOut: { x: center.x + k, y: center.y + radius },
     },
   ];
+};
+
+const HALF_PI = Math.PI / 2;
+
+export const createArcNodes = (
+  center: Vec2,
+  radius: number,
+  startAngle: number,
+  sweep: number,
+): PathNode[] => {
+  const safeRadius = Math.max(0, radius);
+  if (safeRadius === 0) {
+    return [];
+  }
+  const segments = Math.max(1, Math.ceil(Math.abs(sweep) / HALF_PI));
+  const delta = sweep / segments;
+  const nodes: PathNode[] = [];
+  let angle = startAngle;
+  const startPoint = {
+    x: center.x + Math.cos(angle) * safeRadius,
+    y: center.y + Math.sin(angle) * safeRadius,
+  };
+  nodes.push({
+    id: createId('node'),
+    point: startPoint,
+    handleIn: null,
+    handleOut: null,
+  });
+  for (let i = 0; i < segments; i += 1) {
+    const nextAngle = angle + delta;
+    const p0 = nodes[nodes.length - 1];
+    const p3 = {
+      x: center.x + Math.cos(nextAngle) * safeRadius,
+      y: center.y + Math.sin(nextAngle) * safeRadius,
+    };
+    const alpha = (4 / 3) * Math.tan(delta / 4);
+    const handleOut = {
+      x: p0.point.x - Math.sin(angle) * safeRadius * alpha,
+      y: p0.point.y + Math.cos(angle) * safeRadius * alpha,
+    };
+    const handleIn = {
+      x: p3.x + Math.sin(nextAngle) * safeRadius * alpha,
+      y: p3.y - Math.cos(nextAngle) * safeRadius * alpha,
+    };
+    nodes[nodes.length - 1] = {
+      ...p0,
+      handleOut,
+    };
+    nodes.push({
+      id: createId('node'),
+      point: p3,
+      handleIn,
+      handleOut: null,
+    });
+    angle = nextAngle;
+  }
+  return nodes;
 };


### PR DESCRIPTION
## Summary
- persist complete scene snapshots with new workspace store helpers and expose save/load/delete controls in the Scene panel alongside a diameter input for reference circles
- convert DXF ARC and CIRCLE entities into Bézier-based nodes so imported guides stay smooth and reuse the new builders during DXF import
- move grid controls to the left rail, relocate the scene card to the right sidebar, and align the copy action with the other tool buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39c7b92fc8324917ba46c2fb4ede3