### PR TITLE
Add rotate tool with 10° snapping and oval reference circle option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,3 +212,14 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - The Select tool now supports marquee selection by dragging from empty canvas space. Honour the `boxSelection` session in `CanvasViewport` when tweaking pointer handlers and keep Shift-drag additive to the existing node selection.
 - Node drags can move multiple anchors at once; grouped updates route through `translateNodeGroup` so handles shift together and history stays consistent. Avoid bypassing this helper when touching group-drag logic.
 - Hover measurements recognise hits on the oxidation edge as well as the outer contour. Preserve the combined inner/outer hit-testing so hover probes stay responsive even when pointing at the oxide boundary.
+
+## 2025-11-12 — Oxidation dot clipping masks
+
+- `drawOxidationDots` now clips each rendered dot against its closed contour so the exterior half stays invisible. When touching this overlay, keep the per-variant canvas `clip()` guard so mirrored paths inherit the same masking without leaking across shapes.
+- Only closed paths provide a clip polygon; open traces still render the full dot glyph. Preserve this distinction so open-line previews keep showing both sides of the stroke.
+
+## 2025-11-13 — Rotation tool & oval reference guides
+
+- A dedicated Rotate tool now spins the active selection around its average anchor position. Pointer drags accumulate the delta angle and snap to 10° increments; call `rotatePaths` with the snapped delta rather than rewriting node coordinates directly so history entries and oxidation recomputation stay in sync.
+- Locked paths are ignored during a rotation session, matching translation behaviour. If no unlocked paths are selected the tool remains idle—keep this guard in place to avoid accidental transforms.
+- “Add reference circle” can optionally output an oval. The checkbox exposes a horizontal stretch slider (50–200 % of the entered diameter); reuse the stretch helper so the Bézier handles scale with the anchors and keep the generated name in the `Reference oval (V×H μm)` format for library parity.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type ToolId = 'select' | 'line' | 'dot' | 'measure' | 'pan' | 'erase';
+export type ToolId = 'select' | 'line' | 'dot' | 'measure' | 'pan' | 'rotate' | 'erase';
 
 export type PathKind = 'oxided' | 'reference';
 

--- a/src/ui/ToolPanel.tsx
+++ b/src/ui/ToolPanel.tsx
@@ -8,6 +8,7 @@ const tools: Array<{ id: ToolId; label: string; shortcut: string }> = [
   { id: 'dot', label: 'Dot', shortcut: 'D' },
   { id: 'measure', label: 'Measure', shortcut: 'M' },
   { id: 'pan', label: 'Pan', shortcut: 'Space' },
+  { id: 'rotate', label: 'Rotate', shortcut: 'R' },
 ];
 
 export const ToolPanel = () => {

--- a/src/ui/useKeyboardShortcuts.ts
+++ b/src/ui/useKeyboardShortcuts.ts
@@ -7,6 +7,7 @@ const keyMap: Record<string, ToolId> = {
   l: 'line',
   d: 'dot',
   m: 'measure',
+  r: 'rotate',
 };
 
 export const useKeyboardShortcuts = () => {


### PR DESCRIPTION
## Summary
- add a rotate tool that spins selected paths in 10° increments via the new `rotatePaths` action
- extend the scene panel reference circle flow with an optional oval stretch slider and updated naming
- document the rotation workflow and oval reference geometry expectations in the agent handbook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4ea1900b48324bc174f38c6d43f01