### PR TITLE
Refine export overview layout and controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,3 +218,22 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - `drawOxidationDots` now clips each rendered dot against its closed contour so the exterior half stays invisible. When touching this overlay, keep the per-variant canvas `clip()` guard so mirrored paths inherit the same masking without leaking across shapes.
 - Only closed paths provide a clip polygon; open traces still render the full dot glyph. Preserve this distinction so open-line previews keep showing both sides of the stroke.
 
+## 2025-11-13 — Export overview workspace & measurement palette
+
+- The “Export PNG” placeholder became a full export overview. `openExportView`/`closeExportView` toggle a read-only layout that reuses the canvas in presentation mode, locks the tool to measurement by default, and restores the previous tool on exit. Use these store actions whenever you need to enter or leave the export workspace so the UI stays in sync.
+- Export mode renders through `<CanvasViewport variant="export" />`, which suppresses zoom/timeline overlays. Pass the variant instead of cloning the viewport if you need the stripped-down canvas elsewhere.
+- Directional headings now expose a summary compass (`ExportView.tsx`) that mirrors the live weights but pins numeric labels around the rim. Keep the label underline colour in sync with `valueToColor` so screenshots remain legible.
+- Measurements can be saved for export via `exportView.measurements`. Add entries by calling `addExportMeasurement` with a captured `MeasurementProbe`, update colours through `updateExportMeasurementColor`, and remove with `removeExportMeasurement`. Saved probes clone coordinates and receive fresh ids; avoid mutating them in place.
+- Canvas measurement strokes now default to the darker `#1e3a8a` tone to avoid clashing with oxidation dots. Match this hue for any new measurement-related UI to keep styling consistent.
+
+## 2025-11-14 — Export overview layout refinements
+
+- The export compass now renders in a compact 260 px frame with numeric μm labels only. Keep the per-heading underline colours in sync with `valueToColor` and avoid reintroducing compass progress readouts.
+- Export overview’s secondary summary collapsed into the dedicated uniform thickness card—surface extra oxidation metadata elsewhere if needed, but leave this screen focused on the single baseline metric.
+- `<CanvasViewport variant="export" />` should remain editing-neutral: double-click segment toggles stay disabled and the canvas gets the wider 820 px max width so it dominates the layout. Respect these guards when extending export interactions.
+
+## 2025-11-15 — Export capture polish
+
+- Export mode should omit node anchors and Bézier handles entirely. Guard `drawHandles` so the canvas is free of editing affordances while `exportView.active` is true.
+- Compass labels in the export overview must stay on a single line (`value μm`). Preserve the `whitespace-nowrap` styling (or equivalent) when adjusting the markup so right-hand headings don’t wrap.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,3 +237,9 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Export mode should omit node anchors and Bézier handles entirely. Guard `drawHandles` so the canvas is free of editing affordances while `exportView.active` is true.
 - Compass labels in the export overview must stay on a single line (`value μm`). Preserve the `whitespace-nowrap` styling (or equivalent) when adjusting the markup so right-hand headings don’t wrap.
 
+## 2025-11-16 — Export data capture & scene interchange
+
+- Export overview labels now support directional-only and total (directional + uniform) readouts via a toggle in the compass card. Keep the control present when touching this view so screenshot authors can switch modes.
+- Saved export measurements render distance-only callouts on the canvas. When extending measurement drawing, keep export mode hiding labels/angles for saved entries so captures stay clean.
+- Scene library entries can be exported/imported as JSON bundles. Use `handleSceneExport`/`importSceneToLibrary` for new entry points so the `{ version: 1, scene }` payload remains consistent and sanitisation stays centralised.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { StatusBar } from './ui/StatusBar';
 import { ImportExportPanel } from './ui/ImportExportPanel';
 import { ScenePanel } from './ui/ScenePanel';
 import { PathTypePanel } from './ui/PathTypePanel';
+import { ExportView } from './ui/ExportView';
 import { useKeyboardShortcuts } from './ui/useKeyboardShortcuts';
 import { useWorkspaceStore } from './state';
 import { createId } from './utils/ids';
@@ -39,6 +40,7 @@ export const App = () => {
   const panelCollapse = useWorkspaceStore((state) => state.panelCollapse);
   const setPanelCollapsed = useWorkspaceStore((state) => state.setPanelCollapsed);
   const rightCollapsed = panelCollapse.rightSidebar;
+  const exportViewActive = useWorkspaceStore((state) => state.exportView.active);
 
   const rightColumnWidth = rightCollapsed ? 'max-content' : '320px';
 
@@ -69,6 +71,10 @@ export const App = () => {
       markBootstrapped();
     }
   }, [addPath, bootstrapped, markBootstrapped, pathCount, pushWarning]);
+
+  if (exportViewActive) {
+    return <ExportView />;
+  }
 
   return (
     <div className="min-h-screen bg-background px-4 py-6 text-text sm:px-6 lg:px-8">

--- a/src/canvas/measurements.ts
+++ b/src/canvas/measurements.ts
@@ -7,6 +7,7 @@ export const drawMeasurements = (
   measurements: MeasurementState,
   view: ViewTransform,
   saved: ExportMeasurement[] = [],
+  exportMode = false,
 ): void => {
   ctx.save();
   const entries: Array<
@@ -54,7 +55,9 @@ export const drawMeasurements = (
     const angleLabel = `${toDegrees(Math.atan2(probe.b.y - probe.a.y, probe.b.x - probe.a.x)).toFixed(1)}°`;
     const toneVariant = tone === 'hover' ? 'subtle' : 'strong';
     const text = tone === 'saved'
-      ? `${label ?? ''} • ${distanceLabel} • ${angleLabel}`.replace(/^\s*•\s*/, '')
+      ? exportMode
+        ? distanceLabel
+        : `${label ?? ''} • ${distanceLabel} • ${angleLabel}`.replace(/^\s*•\s*/, '')
       : `${distanceLabel} • ${angleLabel}`;
     drawLabel(ctx, midX, midY, text, toneVariant, tone === 'saved' ? color : undefined);
   });

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -104,7 +104,13 @@ export class CanvasRenderer {
       }
     });
     drawSnaps(this.ctx, state.paths, state.measurements, view);
-    drawMeasurements(this.ctx, state.measurements, view, state.exportView.measurements);
+    drawMeasurements(
+      this.ctx,
+      state.measurements,
+      view,
+      state.exportView.measurements,
+      exportMode,
+    );
     this.ctx.restore();
   }
 }

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -79,6 +79,7 @@ export class CanvasRenderer {
     const showDots = state.oxidationVisible;
     const dotCount = state.oxidationDotCount;
     const progress = state.oxidationProgress;
+    const exportMode = state.exportView.active;
 
     state.paths.forEach((path) => {
       const selected = state.selectedPathIds.includes(path.meta.id);
@@ -98,10 +99,12 @@ export class CanvasRenderer {
           showDots,
         );
       }
-      drawHandles(this.ctx, path, selected, view, state.nodeSelection);
+      if (!exportMode) {
+        drawHandles(this.ctx, path, selected, view, state.nodeSelection);
+      }
     });
     drawSnaps(this.ctx, state.paths, state.measurements, view);
-    drawMeasurements(this.ctx, state.measurements, view);
+    drawMeasurements(this.ctx, state.measurements, view, state.exportView.measurements);
     this.ctx.restore();
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,20 @@ export interface StoredShape {
   updatedAt: number;
 }
 
+export interface ExportMeasurement {
+  id: string;
+  label: string;
+  color: string;
+  probe: MeasurementProbe;
+}
+
+export interface ExportViewState {
+  active: boolean;
+  previousTool: ToolId | null;
+  measurements: ExportMeasurement[];
+  sequence: number;
+}
+
 export interface StoredSceneState {
   paths: PathEntity[];
   selectedPathIds: string[];
@@ -95,6 +109,7 @@ export interface StoredSceneState {
   oxidationDotCount: number;
   directionalLinking: boolean;
   panelCollapse: PanelCollapseState;
+  exportView: ExportViewState;
 }
 
 export interface StoredScene {
@@ -171,6 +186,7 @@ export interface WorkspaceSnapshot {
   zoom: number;
   pan: Vec2;
   panelCollapse: PanelCollapseState;
+  exportView: ExportViewState;
 }
 
 export interface WorkspaceState {
@@ -196,6 +212,7 @@ export interface WorkspaceState {
   scenes: StoredScene[];
   zoom: number;
   panelCollapse: PanelCollapseState;
+  exportView: ExportViewState;
 }
 
 export interface ExportedProject {

--- a/src/ui/DirectionalCompass.tsx
+++ b/src/ui/DirectionalCompass.tsx
@@ -93,7 +93,7 @@ export const DirectionalCompass = () => {
   const updateDefaults = useWorkspaceStore((state) => state.updateOxidationDefaults);
   const linking = useWorkspaceStore((state) => state.directionalLinking);
   const setLinking = useWorkspaceStore((state) => state.setDirectionalLinking);
-  const pushWarning = useWorkspaceStore((state) => state.pushWarning);
+  const openExportView = useWorkspaceStore((state) => state.openExportView);
   const oxidationProgress = useWorkspaceStore((state) => state.oxidationProgress);
 
   const activeWeights = defaults.thicknessByDirection.items;
@@ -580,9 +580,9 @@ export const DirectionalCompass = () => {
             <button
               type="button"
               className="rounded-full border border-border bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-accent shadow-sm transition hover:bg-white"
-              onClick={() => pushWarning('PNG export is coming soon.', 'info')}
+              onClick={openExportView}
             >
-              Export PNG
+              Export view
             </button>
           </div>
         )}

--- a/src/ui/ExportView.tsx
+++ b/src/ui/ExportView.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { CanvasViewport } from './CanvasViewport';
 import { useWorkspaceStore } from '../state';
 import type { DirectionWeight } from '../types';
@@ -56,6 +56,11 @@ const polarToCartesian = (angleRad: number, radius: number): { x: number; y: num
 const ExportCompass = () => {
   const defaults = useWorkspaceStore((state) => state.oxidationDefaults);
   const oxidationProgress = useWorkspaceStore((state) => state.oxidationProgress);
+  const [displayMode, setDisplayMode] = useState<'directional' | 'total'>('directional');
+
+  const toggleDisplayMode = () => {
+    setDisplayMode((mode) => (mode === 'directional' ? 'total' : 'directional'));
+  };
 
   const weights = useMemo(
     () => sortByAngle(defaults.thicknessByDirection.items),
@@ -101,9 +106,22 @@ const ExportCompass = () => {
 
   return (
     <div className="rounded-3xl border border-border bg-white/80 p-5 shadow-panel">
-      <div>
-        <h2 className="text-base font-semibold">Directional weights</h2>
-        <p className="text-xs text-muted">Oxide profile snapshot</p>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold">Directional weights</h2>
+          <p className="text-xs text-muted">
+            {displayMode === 'directional'
+              ? 'Showing configured offsets per heading.'
+              : 'Showing offsets plus the uniform baseline.'}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded-full border border-border px-3 py-1 text-[10px] font-semibold uppercase tracking-widest text-muted transition hover:border-accent hover:text-accent"
+          onClick={toggleDisplayMode}
+        >
+          {displayMode === 'directional' ? 'Show totals' : 'Show offsets'}
+        </button>
       </div>
       <div
         className="relative mx-auto mt-4 flex items-center justify-center"
@@ -187,6 +205,10 @@ const ExportCompass = () => {
           const labelRadius = preview.maxRadius + 20;
           const position = polarToCartesian(angleRad, Math.max(labelRadius, OUTER_RADIUS + 20));
           const color = valueToColor(weight.valueUm);
+          const labelValue =
+            displayMode === 'directional'
+              ? weight.valueUm
+              : weight.valueUm + defaults.thicknessUniformUm;
           return (
             <div
               key={`label-${weight.id}`}
@@ -197,7 +219,7 @@ const ExportCompass = () => {
                 className="rounded-full px-2 py-1 whitespace-nowrap"
                 style={{ borderBottom: `2px solid ${color}`, backgroundColor: 'rgba(255,255,255,0.92)' }}
               >
-                {weight.valueUm.toFixed(1)} μm
+                {labelValue.toFixed(1)} μm
               </span>
             </div>
           );

--- a/src/ui/ExportView.tsx
+++ b/src/ui/ExportView.tsx
@@ -1,0 +1,345 @@
+import { useMemo } from 'react';
+import { CanvasViewport } from './CanvasViewport';
+import { useWorkspaceStore } from '../state';
+import type { DirectionWeight } from '../types';
+import { evalThicknessForAngle } from '../geometry';
+
+const CANVAS_SIZE = 260;
+const OUTER_RADIUS = CANVAS_SIZE / 2 - 20;
+const CENTER = CANVAS_SIZE / 2;
+const MIN_SPOKE_RADIUS = 44;
+
+const toRadians = (value: number): number => (value * Math.PI) / 180;
+
+const sortByAngle = (items: DirectionWeight[]): DirectionWeight[] =>
+  [...items].sort((a, b) => a.angleDeg - b.angleDeg);
+
+const interpolate = (start: number[], end: number[], t: number): number[] => [
+  start[0] + (end[0] - start[0]) * t,
+  start[1] + (end[1] - start[1]) * t,
+  start[2] + (end[2] - start[2]) * t,
+];
+
+const gradientStops: { stop: number; color: number[] }[] = [
+  { stop: 0, color: [37, 99, 235] },
+  { stop: 0.35, color: [34, 197, 94] },
+  { stop: 0.7, color: [250, 204, 21] },
+  { stop: 1, color: [239, 68, 68] },
+];
+
+const valueToColor = (value: number): string => {
+  const t = Math.min(Math.max(value / 10, 0), 1);
+  for (let i = 0; i < gradientStops.length - 1; i += 1) {
+    const current = gradientStops[i];
+    const next = gradientStops[i + 1];
+    if (t >= current.stop && t <= next.stop) {
+      const span = (t - current.stop) / (next.stop - current.stop || 1);
+      const [r, g, b] = interpolate(current.color, next.color, span);
+      return `rgb(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)})`;
+    }
+  }
+  const last = gradientStops.at(-1)!;
+  return `rgb(${last.color.map((c) => Math.round(c)).join(', ')})`;
+};
+
+const spokeRadiusForValue = (value: number): number => {
+  const ratio = Math.min(Math.max(value / 10, 0), 1);
+  const maxRadius = OUTER_RADIUS - 24;
+  return MIN_SPOKE_RADIUS + ratio * Math.max(maxRadius - MIN_SPOKE_RADIUS, 0);
+};
+
+const polarToCartesian = (angleRad: number, radius: number): { x: number; y: number } => ({
+  x: CENTER + Math.cos(angleRad) * radius,
+  y: CENTER + Math.sin(angleRad) * radius,
+});
+
+const ExportCompass = () => {
+  const defaults = useWorkspaceStore((state) => state.oxidationDefaults);
+  const oxidationProgress = useWorkspaceStore((state) => state.oxidationProgress);
+
+  const weights = useMemo(
+    () => sortByAngle(defaults.thicknessByDirection.items),
+    [defaults.thicknessByDirection.items],
+  );
+
+  const thicknessOptions = useMemo(
+    () => ({
+      uniformThickness: defaults.thicknessUniformUm,
+      weights,
+      mirrorSymmetry: defaults.mirrorSymmetry,
+      progress: oxidationProgress,
+    }),
+    [defaults.mirrorSymmetry, defaults.thicknessUniformUm, oxidationProgress, weights],
+  );
+
+  const preview = useMemo(() => {
+    const segments = Math.max(96, weights.length * 12, 160);
+    const points: Array<{ x: number; y: number }> = [];
+    let maxRadius = MIN_SPOKE_RADIUS;
+    for (let i = 0; i < segments; i += 1) {
+      const theta = (i / segments) * Math.PI * 2;
+      const totalThickness = weights.length
+        ? evalThicknessForAngle(theta, thicknessOptions)
+        : defaults.thicknessUniformUm * oxidationProgress;
+      const radius = spokeRadiusForValue(totalThickness ?? 0);
+      maxRadius = Math.max(maxRadius, radius);
+      points.push(polarToCartesian(theta, radius));
+    }
+    if (!points.length) {
+      return { path: '', maxRadius: MIN_SPOKE_RADIUS };
+    }
+    const [first, ...rest] = points;
+    const path = [
+      `M ${first.x.toFixed(2)} ${first.y.toFixed(2)}`,
+      ...rest.map((point) => `L ${point.x.toFixed(2)} ${point.y.toFixed(2)}`),
+      'Z',
+    ].join(' ');
+    return { path, maxRadius };
+  }, [defaults.thicknessUniformUm, oxidationProgress, thicknessOptions, weights]);
+
+  const uniformRadius = spokeRadiusForValue(defaults.thicknessUniformUm * oxidationProgress);
+
+  return (
+    <div className="rounded-3xl border border-border bg-white/80 p-5 shadow-panel">
+      <div>
+        <h2 className="text-base font-semibold">Directional weights</h2>
+        <p className="text-xs text-muted">Oxide profile snapshot</p>
+      </div>
+      <div
+        className="relative mx-auto mt-4 flex items-center justify-center"
+        style={{ width: CANVAS_SIZE, height: CANVAS_SIZE }}
+      >
+        <svg width={CANVAS_SIZE} height={CANVAS_SIZE} viewBox={`0 0 ${CANVAS_SIZE} ${CANVAS_SIZE}`}>
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r={OUTER_RADIUS}
+            fill="rgba(255,255,255,0.85)"
+            stroke="#dbe1ea"
+            strokeWidth={2}
+          />
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r={MIN_SPOKE_RADIUS - 10}
+            fill="rgba(30, 64, 175, 0.08)"
+            stroke="rgba(30, 64, 175, 0.3)"
+            strokeWidth={2}
+          />
+          {uniformRadius > MIN_SPOKE_RADIUS && (
+            <circle
+              cx={CENTER}
+              cy={CENTER}
+              r={uniformRadius}
+              fill="rgba(30, 64, 175, 0.05)"
+              stroke="rgba(30, 64, 175, 0.25)"
+              strokeWidth={1.5}
+              strokeDasharray="6 6"
+            />
+          )}
+          {preview.path && (
+            <path
+              d={preview.path}
+              fill="rgba(37, 99, 235, 0.12)"
+              stroke="rgba(30, 64, 175, 0.55)"
+              strokeWidth={2}
+              strokeLinejoin="round"
+            />
+          )}
+          {[0, 45, 90, 135, 180, 225, 270, 315].map((angle) => {
+            const rad = toRadians(angle);
+            const inner = polarToCartesian(rad, OUTER_RADIUS - 12);
+            const outer = polarToCartesian(rad, OUTER_RADIUS - 2);
+            return (
+              <line
+                key={`tick-${angle}`}
+                x1={inner.x}
+                y1={inner.y}
+                x2={outer.x}
+                y2={outer.y}
+                stroke="rgba(148, 163, 184, 0.4)"
+                strokeWidth={2}
+                strokeLinecap="round"
+              />
+            );
+          })}
+          {weights.map((weight) => {
+            const angleRad = toRadians(weight.angleDeg);
+            const start = polarToCartesian(angleRad, MIN_SPOKE_RADIUS - 10);
+            const end = polarToCartesian(angleRad, spokeRadiusForValue(weight.valueUm * oxidationProgress));
+            const color = valueToColor(weight.valueUm);
+            return (
+              <line
+                key={weight.id}
+                x1={start.x}
+                y1={start.y}
+                x2={end.x}
+                y2={end.y}
+                stroke={color}
+                strokeWidth={6}
+                strokeLinecap="round"
+              />
+            );
+          })}
+        </svg>
+        {weights.map((weight) => {
+          const angleRad = toRadians(weight.angleDeg);
+          const labelRadius = preview.maxRadius + 20;
+          const position = polarToCartesian(angleRad, Math.max(labelRadius, OUTER_RADIUS + 20));
+          const color = valueToColor(weight.valueUm);
+          return (
+            <div
+              key={`label-${weight.id}`}
+              className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2 text-[11px] font-semibold text-text"
+              style={{ left: position.x, top: position.y }}
+            >
+              <span
+                className="rounded-full px-2 py-1 whitespace-nowrap"
+                style={{ borderBottom: `2px solid ${color}`, backgroundColor: 'rgba(255,255,255,0.92)' }}
+              >
+                {weight.valueUm.toFixed(1)} μm
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const UniformThicknessCard = () => {
+  const defaults = useWorkspaceStore((state) => state.oxidationDefaults);
+
+  return (
+    <div className="rounded-3xl border border-border bg-white/80 p-5 shadow-panel">
+      <h2 className="text-base font-semibold">Uniform thickness</h2>
+      <p className="mt-1 text-xs text-muted">Baseline layer applied before directional growth.</p>
+      <div className="mt-4 flex items-center justify-between rounded-2xl border border-border/70 bg-white/80 px-4 py-3 shadow-sm">
+        <span className="text-xs uppercase tracking-[0.3em] text-muted">Value</span>
+        <span className="text-lg font-semibold text-text">{defaults.thicknessUniformUm.toFixed(1)} μm</span>
+      </div>
+    </div>
+  );
+};
+
+const ExportMeasurementsPanel = () => {
+  const exportMeasurements = useWorkspaceStore((state) => state.exportView.measurements);
+  const addMeasurement = useWorkspaceStore((state) => state.addExportMeasurement);
+  const removeMeasurement = useWorkspaceStore((state) => state.removeExportMeasurement);
+  const updateColor = useWorkspaceStore((state) => state.updateExportMeasurementColor);
+  const pinnedProbe = useWorkspaceStore((state) => state.measurements.pinnedProbe);
+  const setActiveTool = useWorkspaceStore((state) => state.setActiveTool);
+  const activeTool = useWorkspaceStore((state) => state.activeTool);
+
+  return (
+    <div className="rounded-3xl border border-border bg-white/85 p-6 shadow-panel">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Measurements</h2>
+          <p className="text-xs text-muted">
+            Use the measurement tool to pin spans, then add them to the export list below.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className={`rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-wide transition ${
+              activeTool === 'measure'
+                ? 'border-accent bg-accent/10 text-accent'
+                : 'border-border text-muted hover:border-accent'
+            }`}
+            onClick={() => setActiveTool('measure')}
+          >
+            Measure tool
+          </button>
+          <button
+            type="button"
+            className="rounded-full border border-border bg-white px-4 py-2 text-xs font-semibold uppercase tracking-wide text-accent shadow-sm transition hover:bg-white"
+            onClick={() => pinnedProbe && addMeasurement(pinnedProbe)}
+            disabled={!pinnedProbe}
+          >
+            Add pinned
+          </button>
+        </div>
+      </div>
+      <div className="mt-4 grid gap-4">
+        {exportMeasurements.length === 0 && (
+          <div className="rounded-2xl border border-dashed border-border/70 bg-white/70 px-4 py-6 text-center text-sm text-muted">
+            No saved measurements yet. Pin a measurement on the canvas and press “Add pinned”.
+          </div>
+        )}
+        {exportMeasurements.map((entry) => (
+          <div
+            key={entry.id}
+            className="flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-border/70 bg-white/80 px-4 py-3 shadow-sm"
+          >
+            <div className="flex flex-col gap-1 text-sm">
+              <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted">
+                <span className="font-semibold text-text">{entry.label}</span>
+                <span>• {entry.probe.distance.toFixed(2)} μm</span>
+                <span>• {entry.probe.angleDeg.toFixed(1)}°</span>
+              </div>
+              <div className="text-xs text-muted">
+                A ({entry.probe.a.x.toFixed(1)} μm, {entry.probe.a.y.toFixed(1)} μm) · B (
+                {entry.probe.b.x.toFixed(1)} μm, {entry.probe.b.y.toFixed(1)} μm)
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-2 text-xs text-muted">
+                Color
+                <input
+                  type="color"
+                  value={entry.color}
+                  onChange={(event) => updateColor(entry.id, event.target.value)}
+                  className="h-9 w-9 cursor-pointer rounded-full border border-border"
+                />
+              </label>
+              <button
+                type="button"
+                className="rounded-full border border-border bg-white px-3 py-2 text-xs font-semibold uppercase tracking-wide text-error transition hover:border-error"
+                onClick={() => removeMeasurement(entry.id)}
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const ExportView = () => {
+  const closeExportView = useWorkspaceStore((state) => state.closeExportView);
+
+  return (
+    <div className="min-h-screen bg-background px-4 py-6 text-text sm:px-6 lg:px-10">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6">
+        <header className="flex items-center justify-between">
+          <button
+            type="button"
+            className="rounded-full border border-border bg-white px-4 py-2 text-xs font-semibold uppercase tracking-wide text-accent shadow transition hover:bg-white/90"
+            onClick={closeExportView}
+          >
+            Back to workspace
+          </button>
+          <div className="text-right">
+            <h1 className="text-xl font-semibold">Export overview</h1>
+            <p className="text-xs text-muted">All essential oxidation data in a single screen capture.</p>
+          </div>
+        </header>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)] xl:grid-cols-[minmax(0,0.75fr)_minmax(0,1.25fr)]">
+          <div className="flex flex-col gap-6">
+            <ExportCompass />
+            <UniformThicknessCard />
+          </div>
+          <div className="flex items-center justify-center">
+            <CanvasViewport variant="export" />
+          </div>
+        </div>
+        <ExportMeasurementsPanel />
+      </div>
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- replace the PNG placeholder with an export overview screen and wire it through the store so the main app switches to the new layout
- build the export layout with a presentation compass, oxidation summary, canvas viewport variant, and measurement management card
- darken measurement strokes, support saved export probes, and document the new workflow in the agent handbook
- refine the export overview so the compass is compact, the canvas dominates the screen, the oxidation summary focuses on uniform thickness, and export mode hides line/Bézier editing toggles
- suppress node handles in export captures and enforce single-line compass labels to keep μm readings legible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e50088f6908324b8549190be08a9d7