### PR TITLE
Support offline bundle launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,3 +243,8 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Saved export measurements render distance-only callouts on the canvas. When extending measurement drawing, keep export mode hiding labels/angles for saved entries so captures stay clean.
 - Scene library entries can be exported/imported as JSON bundles. Use `handleSceneExport`/`importSceneToLibrary` for new entry points so the `{ version: 1, scene }` payload remains consistent and sanitisation stays centralised.
 
+## 2025-11-20 — Offline bundle support
+
+- Vite now builds with `base: './'` so production assets resolve when opening `dist/index.html` via the `file://` protocol. Preserve this base when adjusting the config or relative paths will break offline launches.
+- The README documents the offline workflow (build then open the generated HTML). Keep those steps accurate if the build output or folder structure changes.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,4 +247,5 @@ Think of this file as the living design history.  Out-of-date instructions cause
 
 - Vite now builds with `base: './'` so production assets resolve when opening `dist/index.html` via the `file://` protocol. Preserve this base when adjusting the config or relative paths will break offline launches.
 - The README documents the offline workflow (build then open the generated HTML). Keep those steps accurate if the build output or folder structure changes.
+- Browsers that block `localStorage` on `file://` origins must fail gracefully. Use the shared storage resolver in `workspaceStore` and avoid new direct `window.localStorage` calls so offline launches keep working without persistence.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,3 +249,9 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - The README documents the offline workflow (build then open the generated HTML). Keep those steps accurate if the build output or folder structure changes.
 - Browsers that block `localStorage` on `file://` origins must fail gracefully. Use the shared storage resolver in `workspaceStore` and avoid new direct `window.localStorage` calls so offline launches keep working without persistence.
 
+## 2025-11-21 — Electron desktop shell
+
+- Oxid Designer now ships with an Electron wrapper (`electron/main.js`) that loads the offline bundle. Keep the entry point free of bundler-specific imports so it runs after a plain `npm run build`.
+- `package.json` declares `electron:start`/`electron:package` scripts plus an `electron-builder` config. Update all three when moving files so desktop builds keep working.
+- Electron packages rely on the same `dist/index.html`; do not introduce absolute URLs or the shell will boot to a blank window.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,7 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Vite now builds with `base: './'` so production assets resolve when opening `dist/index.html` via the `file://` protocol. Preserve this base when adjusting the config or relative paths will break offline launches.
 - The README documents the offline workflow (build then open the generated HTML). Keep those steps accurate if the build output or folder structure changes.
 - Browsers that block `localStorage` on `file://` origins must fail gracefully. Use the shared storage resolver in `workspaceStore` and avoid new direct `window.localStorage` calls so offline launches keep working without persistence.
+- Production builds disable Vite's modulepreload polyfill so double-click launches avoid `fetch` errors on `file://` URLs. Don't re-enable the polyfill unless you also add a disk-safe loader.
 
 ## 2025-11-21 — Electron desktop shell
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To load the workbench from disk without the Vite dev server:
 2. Run `npm run build` to create the production bundle under `dist/`.
 3. Open `dist/index.html` in a modern browser. All bundle paths are now relative, so the app runs correctly when launched via the `file://` protocol.
    - Browsers that block `localStorage` for `file://` origins simply disable the scene/shape library instead of crashing, so offline sessions remain usable even without persistence.
+   - Module preloading polyfills are disabled in production builds to avoid `fetch` failures on `file://` URLs—modern browsers load the modules natively, so the bundle boots cleanly from disk.
 
 ## Desktop application build
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The development server runs on <http://localhost:5173> by default.
 - `npm run build` – type-check and build the production bundle. The resulting `dist/index.html` can be opened directly from the filesystem for offline review.
 - `npm run preview` – preview a production build locally.
 - `npm run lint` – run ESLint over the source files.
+- `npm run electron:start` – build the production bundle and open it inside the desktop shell.
+- `npm run electron:package` – build the bundle and produce installable Electron packages in `dist/`.
 
 ## Project Structure
 
@@ -43,3 +45,14 @@ To load the workbench from disk without the Vite dev server:
 2. Run `npm run build` to create the production bundle under `dist/`.
 3. Open `dist/index.html` in a modern browser. All bundle paths are now relative, so the app runs correctly when launched via the `file://` protocol.
    - Browsers that block `localStorage` for `file://` origins simply disable the scene/shape library instead of crashing, so offline sessions remain usable even without persistence.
+
+## Desktop application build
+
+If you prefer to run Oxid Designer as a standalone desktop app:
+
+1. Install dependencies with `npm install`.
+2. Run `npm run electron:start` to generate the production bundle and open it inside the lightweight Electron shell.
+   - The command fails if `dist/index.html` is missing, so make sure the build succeeds first.
+3. To generate distributable installers, run `npm run electron:package`. Electron Builder places platform-specific artefacts under `dist/` (for example, `.dmg` on macOS or `.exe` on Windows).
+
+The Electron wrapper loads the same offline-friendly `dist/index.html`, so all geometry tooling and oxidation previews behave identically to the browser version.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ To load the workbench from disk without the Vite dev server:
 1. Install dependencies with `npm install` (one time).
 2. Run `npm run build` to create the production bundle under `dist/`.
 3. Open `dist/index.html` in a modern browser. All bundle paths are now relative, so the app runs correctly when launched via the `file://` protocol.
+   - Browsers that block `localStorage` for `file://` origins simply disable the scene/shape library instead of crashing, so offline sessions remain usable even without persistence.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The development server runs on <http://localhost:5173> by default.
 ## Available Scripts
 
 - `npm run dev` – start the Vite development server.
-- `npm run build` – type-check and build the production bundle.
+- `npm run build` – type-check and build the production bundle. The resulting `dist/index.html` can be opened directly from the filesystem for offline review.
 - `npm run preview` – preview a production build locally.
 - `npm run lint` – run ESLint over the source files.
 
@@ -34,3 +34,11 @@ Tailwind CSS powers the light, minimalist UI theme. Global styles live in `src/i
 ## Import / Export
 
 Use the Project panel within the app to export or import JSON project files. PNG and SVG export buttons currently provide informative stubs for future integrations.
+
+## Running without a local server
+
+To load the workbench from disk without the Vite dev server:
+
+1. Install dependencies with `npm install` (one time).
+2. Run `npm run build` to create the production bundle under `dist/`.
+3. Open `dist/index.html` in a modern browser. All bundle paths are now relative, so the app runs correctly when launched via the `file://` protocol.

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,56 @@
+import { app, BrowserWindow } from 'electron';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+let mainWindow;
+
+function getDistIndexPath() {
+  const htmlPath = join(__dirname, '..', 'dist', 'index.html');
+  if (!existsSync(htmlPath)) {
+    throw new Error(
+      'Missing dist/index.html. Run "npm run build" before launching the desktop shell.'
+    );
+  }
+  return htmlPath;
+}
+
+function createWindow() {
+  const window = new BrowserWindow({
+    width: 1280,
+    height: 900,
+    minWidth: 1024,
+    minHeight: 720,
+    autoHideMenuBar: true,
+    webPreferences: {
+      sandbox: false,
+    },
+  });
+
+  window.loadFile(getDistIndexPath());
+
+  window.on('closed', () => {
+    mainWindow = null;
+  });
+
+  return window;
+}
+
+app.on('ready', () => {
+  mainWindow = createWindow();
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (mainWindow === null) {
+    mainWindow = createWindow();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "main": "electron/main.js",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "electron:start": "npm run build && electron .",
+    "electron:package": "npm run build && electron-builder"
   },
   "dependencies": {
     "bezier-js": "^6.1.4",
@@ -30,6 +33,8 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "electron": "^33.2.0",
+    "electron-builder": "^25.0.5",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
     "postcss": "^8.5.6",
@@ -37,5 +42,20 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7"
+  },
+  "build": {
+    "appId": "com.oxid.designer",
+    "productName": "Oxid Designer",
+    "files": [
+      "dist/**/*",
+      "electron/**/*",
+      "package.json"
+    ],
+    "directories": {
+      "buildResources": "electron/resources"
+    },
+    "extraMetadata": {
+      "main": "electron/main.js"
+    }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
   resolve: {
     alias: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,13 @@ import path from 'node:path'
 // https://vite.dev/config/
 export default defineConfig({
   base: './',
+  build: {
+    modulePreload: {
+      // Fetch-based polyfills break when launching the bundle via the file protocol.
+      // Disable them so offline users can open dist/index.html without a local server.
+      polyfill: false,
+    },
+  },
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- set Vite's base path to `./` so production bundles open correctly from the filesystem
- document the build-and-open workflow for offline usage in the README
- note the offline support requirement in the agent handbook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52e7959108324a4da1aaf62feb6df