### PR TITLE
Add helper script for launching dev server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,4 +250,5 @@ Think of this file as the living design history.  Out-of-date instructions cause
 ## 2025-11-18 — Canvas backing-store rounding fix
 
 - Canvas resizing now rounds the backing-store dimensions **upwards** (`Math.ceil`) when applying device-pixel ratio scaling. This prevents sub-pixel gutters from accumulating stale frame data along the lower-right edge. Keep using ceiling rounding if you touch `CanvasRenderer.resize()` so the render loop always clears the full visible surface.
+- `CanvasRenderer` stores the CSS pixel width/height captured from the `ResizeObserver` and clears the backing store with the identity transform before reapplying DPR scaling each frame. Preserve this two-step clear so fractional CSS sizes map cleanly to device pixels without leaving a ghosted band along the bottom-right edge.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,3 +247,7 @@ Think of this file as the living design history.  Out-of-date instructions cause
 
 - A `start-dev.sh` script now bootstraps dependencies (if `node_modules` is missing), launches `npm run dev` with overridable `HOST`/`PORT`, waits for the server to respond, and opens the workspace URL in the default browser. It streams logs until you exit; feel free to pass extra Vite flags via `VITE_DEV_ARGS`.
 
+## 2025-11-18 — Canvas backing-store rounding fix
+
+- Canvas resizing now rounds the backing-store dimensions **upwards** (`Math.ceil`) when applying device-pixel ratio scaling. This prevents sub-pixel gutters from accumulating stale frame data along the lower-right edge. Keep using ceiling rounding if you touch `CanvasRenderer.resize()` so the render loop always clears the full visible surface.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,3 +243,7 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - Saved export measurements render distance-only callouts on the canvas. When extending measurement drawing, keep export mode hiding labels/angles for saved entries so captures stay clean.
 - Scene library entries can be exported/imported as JSON bundles. Use `handleSceneExport`/`importSceneToLibrary` for new entry points so the `{ version: 1, scene }` payload remains consistent and sanitisation stays centralised.
 
+## 2025-11-17 — Dev server helper script
+
+- A `start-dev.sh` script now bootstraps dependencies (if `node_modules` is missing), launches `npm run dev` with overridable `HOST`/`PORT`, waits for the server to respond, and opens the workspace URL in the default browser. It streams logs until you exit; feel free to pass extra Vite flags via `VITE_DEV_ARGS`.
+

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -55,8 +55,8 @@ export class CanvasRenderer {
 
   private resize(): void {
     const { width, height } = this.canvas.getBoundingClientRect();
-    const pixelWidth = Math.max(1, Math.floor(width * this.dpr));
-    const pixelHeight = Math.max(1, Math.floor(height * this.dpr));
+    const pixelWidth = Math.max(1, Math.ceil(width * this.dpr));
+    const pixelHeight = Math.max(1, Math.ceil(height * this.dpr));
     if (this.canvas.width !== pixelWidth || this.canvas.height !== pixelHeight) {
       this.canvas.width = pixelWidth;
       this.canvas.height = pixelHeight;

--- a/src/canvas/renderer.ts
+++ b/src/canvas/renderer.ts
@@ -23,6 +23,10 @@ export class CanvasRenderer {
 
   private getState: StateGetter;
 
+  private cssWidth = 0;
+
+  private cssHeight = 0;
+
   constructor(canvas: HTMLCanvasElement, getState: StateGetter) {
     this.canvas = canvas;
     this.getState = getState;
@@ -55,6 +59,8 @@ export class CanvasRenderer {
 
   private resize(): void {
     const { width, height } = this.canvas.getBoundingClientRect();
+    this.cssWidth = width;
+    this.cssHeight = height;
     const pixelWidth = Math.max(1, Math.ceil(width * this.dpr));
     const pixelHeight = Math.max(1, Math.ceil(height * this.dpr));
     if (this.canvas.width !== pixelWidth || this.canvas.height !== pixelHeight) {
@@ -67,11 +73,16 @@ export class CanvasRenderer {
   private render(): void {
     const state = this.getState();
     const { width, height } = this.canvas;
+
+    this.ctx.save();
+    this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+    this.ctx.clearRect(0, 0, width, height);
+    this.ctx.restore();
+
     this.ctx.save();
     this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
-    this.ctx.clearRect(0, 0, width, height);
-    const logicalWidth = width / this.dpr;
-    const logicalHeight = height / this.dpr;
+    const logicalWidth = this.cssWidth || width / this.dpr;
+    const logicalHeight = this.cssHeight || height / this.dpr;
     const view = computeViewTransform(logicalWidth, logicalHeight, state.zoom, state.pan);
     drawGrid(this.ctx, state.grid, view);
     drawMirrorAxes(this.ctx, state.mirror, view);

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve repository root relative to this script
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+# Ensure dependencies are installed before starting the dev server
+if [ ! -d "node_modules" ]; then
+  echo "Installing dependencies (node_modules not found)..."
+  npm install
+fi
+
+HOST=${HOST:-127.0.0.1}
+PORT=${PORT:-5173}
+EXTRA_ARGS=()
+
+if [ -n "${VITE_DEV_ARGS:-}" ]; then
+  # Allow callers to pass additional arguments to the Vite dev server
+  # as a single space-separated string, e.g. "--host 0.0.0.0 --open".
+  # shellcheck disable=SC2206
+  EXTRA_ARGS=(${VITE_DEV_ARGS})
+fi
+
+# Start the dev server in the background so we can open the browser after it is ready.
+echo "Starting dev server on http://${HOST}:${PORT} ..."
+nohup npm run dev -- --host "$HOST" --port "$PORT" "${EXTRA_ARGS[@]}" >/tmp/vite-dev.log 2>&1 &
+DEV_PID=$!
+
+echo "Dev server PID: $DEV_PID"
+
+cleanup() {
+  if ps -p $DEV_PID > /dev/null 2>&1; then
+    echo "Stopping dev server (PID $DEV_PID)..."
+    kill $DEV_PID 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# Wait until the server responds before opening the browser.
+ATTEMPTS=0
+MAX_ATTEMPTS=${MAX_ATTEMPTS:-60}
+SLEEP_SECONDS=${SLEEP_SECONDS:-1}
+
+until curl -s "http://$HOST:$PORT" >/dev/null 2>&1; do
+  ATTEMPTS=$((ATTEMPTS + 1))
+  if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+    echo "Dev server did not start within $((MAX_ATTEMPTS * SLEEP_SECONDS)) seconds."
+    wait $DEV_PID || true
+    exit 1
+  fi
+  sleep "$SLEEP_SECONDS"
+done
+
+echo "Dev server is running. Opening browser..."
+
+open_in_browser() {
+  local url="$1"
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 &
+  elif command -v open >/dev/null 2>&1; then
+    open "$url" &
+  elif command -v start >/dev/null 2>&1; then
+    start "$url" &
+  else
+    echo "Could not find a command to open the browser automatically."
+    echo "Please open $url manually."
+    return 1
+  fi
+  return 0
+}
+
+open_in_browser "http://$HOST:$PORT" || true
+
+echo "Streaming dev server logs. Press Ctrl+C to stop."
+tail -f /tmp/vite-dev.log &
+TAIL_PID=$!
+wait $DEV_PID
+kill $TAIL_PID 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add a start-dev.sh convenience script that installs dependencies if needed, starts the Vite dev server, and opens the app in a browser automatically
- document the new workflow helper in the agent handbook

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e53f05707083248bb5710db4b3290f