### PR TITLE
Implement proportional directional compass linking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,3 +200,8 @@ Think of this file as the living design history.  Out-of-date instructions cause
 - The path type selector now lives on the right rail beneath the Oxidation card. Keep its mixed-selection banner and reuse `setPathType` so undo/redo and the geometry pipeline stay consistent when flipping modes.
 - DXF import now approximates `ARC` and `CIRCLE` entities into polylines (64 segments for a full circle). Preserve this conversion so guides from AutoCAD round-trip without manual edits, and keep centring the result in the 50 μm workspace before adding paths.
 - The canvas centre column no longer hard-limits its width when the sidebar is expanded, ensuring the gap matches the left rail, and zoom tops out at ×4. Honour these bounds when adjusting layout or viewport behaviour.
+
+## 2025-11-10 — Proportional compass linking
+
+- Compass “linked adjustments” now scale proportionally: when one heading doubles, all other headings double too. Preserve the guard that skips propagation if the source value is ≤ 0 so zeroed spokes don’t rescale the rest of the compass.
+- The toggle tooltip now reads “Proportional adjustments enabled/disabled”. Match this wording in future UI tweaks so users understand the proportional behaviour.

--- a/src/ui/DirectionalCompass.tsx
+++ b/src/ui/DirectionalCompass.tsx
@@ -168,11 +168,14 @@ export const DirectionalCompass = () => {
         if (index === -1) return next;
         const clamped = clampValue(value);
         if (linking && next.length > 0) {
-          const delta = clamped - next[index].valueUm;
-          return next.map((item) => ({
-            ...item,
-            valueUm: clampValue(item.valueUm + delta),
-          }));
+          const currentValue = next[index].valueUm;
+          if (currentValue > 0) {
+            const ratio = clamped / currentValue;
+            return next.map((item) => ({
+              ...item,
+              valueUm: clampValue(item.valueUm * ratio),
+            }));
+          }
         }
         next[index] = { ...next[index], valueUm: clamped };
         return next;
@@ -364,7 +367,7 @@ export const DirectionalCompass = () => {
               linking ? 'border-accent bg-accent/10 text-accent' : 'border-border text-muted hover:border-accent'
             }`}
             onClick={() => setLinking(!linking)}
-            title={linking ? 'Linked adjustments enabled' : 'Linked adjustments disabled'}
+            title={linking ? 'Proportional adjustments enabled' : 'Proportional adjustments disabled'}
           >
             <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
               <path


### PR DESCRIPTION
## Summary
- switch linked compass adjustments to scale values proportionally when the source heading changes
- keep linked propagation disabled when the source value is zero or negative and update the linking tooltip copy
- document the proportional behaviour in the agent handbook

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6718e1e408324adb51608044bb9ce